### PR TITLE
Feat: #23 뷰에 기능 입히기 : Player 재생 제어 위주로

### DIFF
--- a/DancingMarker/DancingMarker.xcodeproj/project.pbxproj
+++ b/DancingMarker/DancingMarker.xcodeproj/project.pbxproj
@@ -25,6 +25,8 @@
 		901BF9B22C2A52B700C02FF9 /* WatchMarkerDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 901BF9B12C2A52B700C02FF9 /* WatchMarkerDetailView.swift */; };
 		901BF9B42C2A52C600C02FF9 /* WatchMarkerEditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 901BF9B32C2A52C600C02FF9 /* WatchMarkerEditView.swift */; };
 		901BF9B62C2A533200C02FF9 /* WatchNavigationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 901BF9B52C2A533200C02FF9 /* WatchNavigationManager.swift */; };
+		902077062C458ABB00988D2B /* WatchViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 902077052C458ABB00988D2B /* WatchViewModel.swift */; };
+		902077082C464CB800988D2B /* PlayerModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 902077072C464CB800988D2B /* PlayerModel.swift */; };
 		90A4722A2C45080D008577A2 /* WatchConnectivity.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 90A472292C45080D008577A2 /* WatchConnectivity.framework */; };
 		90A4722C2C450825008577A2 /* WatchConnectivity.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 90A4722B2C450825008577A2 /* WatchConnectivity.framework */; };
 		90A4722F2C450867008577A2 /* WCManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90A4722E2C450867008577A2 /* WCManager.swift */; };
@@ -82,6 +84,8 @@
 		901BF9B12C2A52B700C02FF9 /* WatchMarkerDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchMarkerDetailView.swift; sourceTree = "<group>"; };
 		901BF9B32C2A52C600C02FF9 /* WatchMarkerEditView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchMarkerEditView.swift; sourceTree = "<group>"; };
 		901BF9B52C2A533200C02FF9 /* WatchNavigationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchNavigationManager.swift; sourceTree = "<group>"; };
+		902077052C458ABB00988D2B /* WatchViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchViewModel.swift; sourceTree = "<group>"; };
+		902077072C464CB800988D2B /* PlayerModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerModel.swift; sourceTree = "<group>"; };
 		90A472292C45080D008577A2 /* WatchConnectivity.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WatchConnectivity.framework; path = Platforms/WatchOS.platform/Developer/SDKs/WatchOS10.5.sdk/System/Library/Frameworks/WatchConnectivity.framework; sourceTree = DEVELOPER_DIR; };
 		90A4722B2C450825008577A2 /* WatchConnectivity.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WatchConnectivity.framework; path = System/Library/Frameworks/WatchConnectivity.framework; sourceTree = SDKROOT; };
 		90A4722E2C450867008577A2 /* WCManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WCManager.swift; sourceTree = "<group>"; };
@@ -155,6 +159,7 @@
 				90E28F4F2C2D05A3009098BE /* MusicEditView.swift */,
 				90E28F512C2D05B1009098BE /* PlayingView.swift */,
 				90E28F552C2D092E009098BE /* NavigationManager.swift */,
+				902077072C464CB800988D2B /* PlayerModel.swift */,
 				901BF9842C29804B00C02FF9 /* Assets.xcassets */,
 				901BF9862C29804B00C02FF9 /* Preview Content */,
 			);
@@ -174,6 +179,7 @@
 			children = (
 				901BF9B72C2A5F5D00C02FF9 /* View */,
 				901BF9B52C2A533200C02FF9 /* WatchNavigationManager.swift */,
+				902077052C458ABB00988D2B /* WatchViewModel.swift */,
 				901BF9982C29809A00C02FF9 /* Assets.xcassets */,
 				901BF99A2C29809A00C02FF9 /* Preview Content */,
 			);
@@ -326,6 +332,7 @@
 				901BF9832C29804A00C02FF9 /* ContentView.swift in Sources */,
 				901BF9812C29804A00C02FF9 /* DancingMarkerApp.swift in Sources */,
 				90E28F582C2D0D89009098BE /* NowPlayingView.swift in Sources */,
+				902077082C464CB800988D2B /* PlayerModel.swift in Sources */,
 				90E28F502C2D05A3009098BE /* MusicEditView.swift in Sources */,
 				90E28F522C2D05B1009098BE /* PlayingView.swift in Sources */,
 				90A4722F2C450867008577A2 /* WCManager.swift in Sources */,
@@ -346,6 +353,7 @@
 				90A472322C450AB6008577A2 /* WCManager.swift in Sources */,
 				901BF9B42C2A52C600C02FF9 /* WatchMarkerEditView.swift in Sources */,
 				901BF9A82C2A525700C02FF9 /* WatchMusicListView.swift in Sources */,
+				902077062C458ABB00988D2B /* WatchViewModel.swift in Sources */,
 				901BF9AA2C2A526E00C02FF9 /* WatchPlayingView.swift in Sources */,
 				901BF9AC2C2A527F00C02FF9 /* WatchPlayingMarkerView.swift in Sources */,
 				5104B7F82C3D6C3F008E10E8 /* Music.swift in Sources */,

--- a/DancingMarker/DancingMarker/DancingMarkerApp.swift
+++ b/DancingMarker/DancingMarker/DancingMarkerApp.swift
@@ -21,10 +21,13 @@ struct DancingMarkerApp: App {
             }
         }()
     
+    @StateObject var viewModel = PlayerModel(connectivityManager: WatchConnectivityManager())
+
     var body: some Scene {
         WindowGroup {
             ContentView()
                 .modelContainer(modelContainer)
+                .environmentObject(viewModel)
                 .preferredColorScheme(/*@START_MENU_TOKEN@*/.dark/*@END_MENU_TOKEN@*/)
         }
     }

--- a/DancingMarker/DancingMarker/MusicListView.swift
+++ b/DancingMarker/DancingMarker/MusicListView.swift
@@ -14,6 +14,7 @@ struct MusicListView: View {
     @Environment(\.modelContext) private var modelContext
     @Query var musicList: [Music] = []
     @State private var isFileImporterPresented: Bool = false
+    @EnvironmentObject var playerModel: PlayerModel
     
     var body: some View {
         VStack {
@@ -51,7 +52,10 @@ struct MusicListView: View {
                         
                     }
                     .onTapGesture {
-                        navigationManager.push(to: .playing(music: music))
+                        DispatchQueue.main.async{
+                            playerModel.music = music
+                            navigationManager.push(to: .playing)
+                        }
                     }
                 }
                 .listStyle(.inset)
@@ -122,7 +126,8 @@ struct MusicListView: View {
             // 파일 복사
             try FileManager.default.copyItem(at: url, to: destinationURL)
             
-            let markers: [TimeInterval] = [] // 추후에 실제 마커 데이터를 추가해야 함
+            let emptyTimeInterval: TimeInterval = 5999.0
+            let markers: [TimeInterval] = [emptyTimeInterval, emptyTimeInterval, emptyTimeInterval] // 추후에 실제 마커 데이터를 추가해야 함
             
             let newMusic = Music(title: title, artist: artist, path: destinationURL, markers: markers, albumArt: albumArt)
             

--- a/DancingMarker/DancingMarker/NavigationManager.swift
+++ b/DancingMarker/DancingMarker/NavigationManager.swift
@@ -11,7 +11,7 @@ enum PathType: Hashable {
     case musicList
     case musicadd
     case musicedit
-    case playing(music: Music)
+    case playing
     case nowplaying
 }
 
@@ -28,8 +28,8 @@ extension PathType {
         case .musicedit:
             MusicEditView()
             
-        case .playing(let music):
-            PlayingView(music: music)
+        case .playing:
+            PlayingView()
             
         case .nowplaying:
             NowPlayingView()

--- a/DancingMarker/DancingMarker/PlayerModel.swift
+++ b/DancingMarker/DancingMarker/PlayerModel.swift
@@ -1,0 +1,292 @@
+//
+//  ViewModel.swift
+//  DancingMarker
+//
+//  Created by 변준섭 on 7/16/24.
+//
+
+import SwiftUI
+import NotificationCenter
+import AVFoundation
+import MediaPlayer
+
+class PlayerModel: ObservableObject {
+    
+    var music: Music?
+    @Environment(\.modelContext) private var modelContext
+    var connectivityManager: WatchConnectivityManager
+
+    @Published var progress: Double = 0.0 // 예시로 초기값 설정
+    @Published var formattedProgress = "0:00"
+    @Published var formattedDuration = "0:00"
+    @Published var duration: TimeInterval = 0.0 // 예시로 재생 시간 설정
+    @Published var currentTime: TimeInterval = 0.0 // 예시로 현재 시간 설정
+    
+    @Published var audioPlayer: AVAudioPlayer?
+    @Published var playbackRate: Float = 1.0
+    @Published var isPlaying = false
+    @Published var isDragging = false
+    
+    @Published var countNum: Int = 0
+
+
+    init(connectivityManager: WatchConnectivityManager) {
+        self.connectivityManager = connectivityManager
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(notificationPlaytoggleAction),
+            name: .plusCount,
+            object: nil
+        )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(notificationForwardAction),
+            name: .forward,
+            object: nil
+        )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(notificationBackwardAction),
+            name: .backward,
+            object: nil
+        )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(notificationMarkerPlayAction),
+            name: .markerPlay,
+            object: nil
+        )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(notificationMarkerSaveAction),
+            name: .markerSave,
+            object: nil
+        )
+    }
+    
+    @objc func notificationPlaytoggleAction(_ notification: Notification) {
+        self.countNum = countNum + 1
+        togglePlayback()
+    }
+    
+    
+    @objc func notificationForwardAction(_ notification: Notification) {
+        self.countNum = countNum + 1
+        forward5Sec()
+    }
+    
+    @objc func notificationBackwardAction(_ notification: Notification) {
+        self.countNum = countNum + 1
+        backward5Sec()
+    }
+    
+    @objc func notificationMarkerPlayAction(_ notification: Notification) {
+        self.countNum = countNum + 1
+        guard let music = music else { return }
+        
+        if let index = notification.object as? Int, index >= 0, index < music.markers.count {
+            let marker = music.markers[index]
+            guard let audioPlayer = audioPlayer else { return }
+            audioPlayer.currentTime = marker
+            self.progress = CGFloat(marker / self.duration)
+            self.formattedProgress = self.formattedTime(marker)
+            audioPlayer.play()
+            self.isPlaying = true
+        } else {
+            print("Invalid marker index or index out of bounds")
+        }
+    }
+    
+    @objc func notificationMarkerSaveAction(_ notification: Notification) {
+        self.countNum = countNum + 1
+        guard let music = music else { return }
+        if let index = notification.object as? Int, index >= 0, index < music.markers.count {
+            guard let audioPlayer = audioPlayer else { return}
+            music.markers[index] = audioPlayer.currentTime
+            self.connectivityManager.sendMarkersToWatch(music.markers)
+        } else {
+            print("Invalid marker index or index out of bounds")
+        }
+    }
+    
+    func addMarkerButton(index: Int) -> some View {
+        Button(action: {
+            DispatchQueue.main.async{
+                guard let music = self.music else { return }
+                self.addMarker(at: index)
+                self.connectivityManager.sendMarkersToWatch(music.markers)
+            }
+            
+        }) {
+            Text("추가")
+                .font(.title3)
+                .foregroundColor(.white)
+                .frame(width: 360, height: 60)
+                .background(Color.buttonDarkGray)
+                .cornerRadius(12)
+        }
+    }
+    
+    func addMarker(at index: Int) {
+        guard let audioPlayer = audioPlayer else { return }
+        guard let music = music else { return }
+        let newMarker = audioPlayer.currentTime
+        
+//        if music.markers.count > index {
+//            music.markers[index] = newMarker
+//        } else {
+//            music.markers.append(newMarker)
+//        }
+        music.markers[index] = newMarker
+        
+        do {
+            try modelContext.save()
+        } catch {
+            print("Failed to save context: \(error.localizedDescription)")
+        }
+    }
+    
+    @ViewBuilder
+    func markerButton(for marker: TimeInterval) -> some View {
+        Button(action: {
+            self.moveToMarker(marker)
+        }) {
+            Text(formattedTime(marker))
+                .font(.title3)
+                .italic()
+                .foregroundColor(.black)
+                .frame(width: 360, height: 60)
+                .background(Color.primaryYellow)
+                .cornerRadius(12)
+        }
+    }
+    
+    private func moveToMarker(_ marker: TimeInterval) {
+        self.audioPlayer?.currentTime = marker
+        self.progress = CGFloat(marker / self.duration)
+        self.formattedProgress = self.formattedTime(marker)
+        audioPlayer?.play()
+        isPlaying = true
+    }
+    
+    func formattedTime(_ time: TimeInterval) -> String {
+        let formatter = DateComponentsFormatter()
+        formatter.allowedUnits = [.minute, .second]
+        formatter.unitsStyle = .positional
+        formatter.zeroFormattingBehavior = [.pad]
+        return formatter.string(from: time)!
+    }
+    
+    /// 배속 조절 기능
+    func decreasePlaybackRate() {
+        if self.playbackRate > 0.5 {
+            self.playbackRate -= 0.1
+            self.updateAudioPlayer()
+        }
+    }
+    
+    func increasePlaybackRate() {
+        if self.playbackRate < 2.0 {
+            self.playbackRate += 0.1
+            self.updateAudioPlayer()
+        }
+    }
+    
+    func updateAudioPlayer() {
+        guard let audioPlayer = audioPlayer else { return }
+        audioPlayer.rate = playbackRate
+        
+    }
+    
+    func updateAudioPlayer(with time: TimeInterval) {
+        guard let audioPlayer = audioPlayer else { return }
+        audioPlayer.currentTime = time
+    }
+    
+    /// 음원 재생, 조작, 초기화
+    func initAudioPlayer() {
+        guard let music = music else { return }
+        
+        let formatter = DateComponentsFormatter()
+        formatter.allowedUnits = [.minute, .second]
+        formatter.unitsStyle = .positional
+        formatter.zeroFormattingBehavior = [.pad]
+        
+        print("Attempting to load file at path: \(music.path)")
+        
+        // 파일 존재 여부 확인
+        guard FileManager.default.fileExists(atPath: music.path.path) else {
+            print("File not found at path: \(music.path)")
+            return
+        }
+        
+        do {
+            // AVAudioSession 설정
+            try AVAudioSession.sharedInstance().setCategory(.playback, mode: .default, options: [])
+            try AVAudioSession.sharedInstance().setActive(true)
+            
+            // AVAudioPlayer 초기화
+            self.audioPlayer = try AVAudioPlayer(contentsOf: music.path)
+            guard let audioPlayer = self.audioPlayer else {
+                print("Failed to initialize audio player")
+                return
+            }
+            
+            // 오디오 플레이어 준비 및 속성 설정
+            audioPlayer.prepareToPlay()
+            audioPlayer.enableRate = true
+            
+            // 포맷된 길이 설정
+            formattedDuration = formatter.string(from: audioPlayer.duration) ?? "0:00"
+            duration = audioPlayer.duration
+            
+            // 타이머 설정
+            Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true) { _ in
+                if !audioPlayer.isPlaying {
+                    self.isPlaying = false
+                }
+                
+                if !self.isDragging {
+                    self.currentTime = audioPlayer.currentTime
+                    self.progress = audioPlayer.duration > 0 ? Double(audioPlayer.currentTime / audioPlayer.duration) : 0
+                    self.formattedProgress = self.formattedTime(audioPlayer.currentTime)
+                }
+            }
+        } catch {
+            print("Error initializing audio player: \(error.localizedDescription)")
+        }
+    }
+    
+    func togglePlayback() {
+        if let audioPlayer = audioPlayer {
+            if self.isPlaying {
+                audioPlayer.pause()
+            } else {
+                audioPlayer.play()
+            }
+            self.isPlaying.toggle()
+        }
+    }
+    
+    /// 음원 5초 앞으로 뒤로 가기 기능
+    func seekToTime(to time: TimeInterval) {
+        guard let player = audioPlayer else { return }
+        player.currentTime = time
+        progress = CGFloat(time / player.duration)
+        formattedProgress = formattedTime(time)
+    }
+    
+    func backward5Sec() {
+        guard let player = audioPlayer else { return }
+        let newTime = max(player.currentTime - 5, 0)
+        seekToTime(to: newTime)
+        // 제어 센터 업데이트 코드 추가
+    }
+    
+    func forward5Sec() {
+        guard let player = audioPlayer else { return }
+        let newTime = min(player.currentTime + 5, player.duration)
+        seekToTime(to: newTime)
+        // 제어 센터 업데이트 코드 추가
+    }
+}

--- a/DancingMarker/DancingMarker/PlayingView.swift
+++ b/DancingMarker/DancingMarker/PlayingView.swift
@@ -11,43 +11,36 @@ import AVFoundation
 struct PlayingView: View {
     @Environment(NavigationManager.self) var navigationManager
     @Environment(\.modelContext) private var modelContext
-    var music: Music
-    
-    /// 슬라이드용 임시 음원 정보
-    @State private var progress: Double = 0.0 // 예시로 초기값 설정
-    @State private var formattedProgress = "0:00"
-    @State private var formattedDuration = "0:00"
-    @State private var duration: TimeInterval = 0.0 // 예시로 재생 시간 설정
-    @State private var currentTime: TimeInterval = 0.0 // 예시로 현재 시간 설정
-    
-    @State var audioPlayer: AVAudioPlayer?
-    @State private var playbackRate: Float = 1.0
-    @State private var isPlaying = false
-    @State private var isDragging = false
-    
+    @EnvironmentObject var playerModel: PlayerModel
+
     var body: some View {
         VStack {
             /// 음원 정보
             HStack(spacing: 10) {
-                if let albumArtData = music.albumArt, let albumArt = UIImage(data: albumArtData) {
-                    Image(uiImage: albumArt)
-                        .resizable()
-                        .frame(width: 66, height: 66)
-                        .cornerRadius(13)
-                } else {
-                    RoundedRectangle(cornerRadius: 13)
-                        .fill(Color.gray)
-                        .frame(width: 66, height: 66)
+                if let music = playerModel.music {
+                    
+                    if let albumArtData = music.albumArt, let albumArt = UIImage(data: albumArtData) {
+                        Image(uiImage: albumArt)
+                            .resizable()
+                            .frame(width: 66, height: 66)
+                            .cornerRadius(13)
+                    } else {
+                        RoundedRectangle(cornerRadius: 13)
+                            .fill(Color.gray)
+                            .frame(width: 66, height: 66)
+                    }
+                    
+                    VStack(alignment: .leading, spacing: 12) {
+                        Text(music.title)
+                            .font(.title3)
+                            .bold()
+                        Text(music.artist)
+                            .font(.body)
+                    }
+                    Spacer()
+                }else {
+                    Text("선택된 음악이 없습니다.")
                 }
-                
-                VStack(alignment: .leading, spacing: 12) {
-                    Text(music.title)
-                        .font(.title3)
-                        .bold()
-                    Text(music.artist)
-                        .font(.body)
-                }
-                Spacer()
             }
             .padding(.vertical, 12)
             
@@ -61,7 +54,7 @@ struct PlayingView: View {
                 .overlay(
                     HStack(spacing: 10) {
                         Button(action: {
-                            decreasePlaybackRate()
+                            playerModel.decreasePlaybackRate()
                         }) {
                             Image(systemName: "minus")
                                 .foregroundStyle(.white)
@@ -69,17 +62,17 @@ struct PlayingView: View {
                         Spacer()
                         
                         Button(action: {
-                            self.playbackRate = 1.0
-                            self.updateAudioPlayer()
+                            playerModel.playbackRate = 1.0
+                            playerModel.updateAudioPlayer()
                         }) {
-                            Text(String(format: "x%.1f", self.playbackRate))
+                            Text(String(format: "x%.1f", playerModel.playbackRate))
                                 .font(.title3)
                                 .foregroundColor(.white)
                         }
                         Spacer()
                         
                         Button(action: {
-                            increasePlaybackRate()
+                            playerModel.increasePlaybackRate()
                         }) {
                             Image(systemName: "plus")
                                 .foregroundStyle(.white)
@@ -99,25 +92,25 @@ struct PlayingView: View {
                         
                         Rectangle()
                             .foregroundColor(.white)
-                            .frame(width: geometry.size.width * CGFloat(self.progress), height: geometry.size.height)
+                            .frame(width: geometry.size.width * CGFloat(playerModel.progress), height: geometry.size.height)
                     }
                     .cornerRadius(12)
                     .gesture(DragGesture(minimumDistance: 0)
                         .onChanged({ value in
                             let newProgress = min(max(0, Double(value.location.x / geometry.size.width)), 1.0)
-                            self.progress = newProgress
-                            let newTime = newProgress * self.duration
-                            self.updateAudioPlayer(with: newTime)
-                            self.currentTime = newTime
-                            self.formattedProgress = self.formattedTime(newTime)
+                            playerModel.progress = newProgress
+                            let newTime = newProgress * playerModel.duration
+                            playerModel.updateAudioPlayer(with: newTime)
+                            playerModel.currentTime = newTime
+                            playerModel.formattedProgress = playerModel.formattedTime(newTime)
                         }))
                 }
                 .frame(height: 5)
                 
                 HStack {
-                    Text("\(self.formattedProgress)")
+                    Text("\(playerModel.formattedProgress)")
                     Spacer()
-                    Text("\(self.formattedDuration)")
+                    Text("\(playerModel.formattedDuration)")
                 }
             }
             .padding(.bottom, 40)
@@ -128,7 +121,7 @@ struct PlayingView: View {
                     .frame(width: 60)
                     .overlay(
                         Button(action: {
-                            backward5Sec()
+                            playerModel.backward5Sec()
                         }) {
                             Image(systemName: "gobackward.5")
                                 .resizable()
@@ -144,9 +137,9 @@ struct PlayingView: View {
                     .frame(width: 80)
                     .overlay(
                         Button(action: {
-                            togglePlayback()
+                            playerModel.togglePlayback()
                         }) {
-                            Image(systemName: self.isPlaying ? "pause.fill" : "play.fill")
+                            Image(systemName: playerModel.isPlaying ? "pause.fill" : "play.fill")
                                 .resizable()
                                 .scaledToFit()
                                 .frame(width: 30)
@@ -161,7 +154,7 @@ struct PlayingView: View {
                     .frame(width: 60)
                     .overlay(
                         Button(action: {
-                            forward5Sec()
+                            playerModel.forward5Sec()
                         }) {
                             Image(systemName: "goforward.5")
                                 .resizable()
@@ -176,7 +169,7 @@ struct PlayingView: View {
         }
         .padding(.horizontal, 16)
         .onAppear {
-            initAudioPlayer()
+            playerModel.initAudioPlayer()
         }
         .navigationBarTitleDisplayMode(.inline)
         .navigationTitle("")
@@ -196,189 +189,20 @@ struct PlayingView: View {
             .padding(.vertical, 12)
             
             VStack {
-                ForEach(0..<3, id: \.self) { index in
-                    if index < music.markers.count {
-                        markerButton(for: music.markers[index])
-                    } else {
-                        addMarkerButton(index: index)
+                if let music = playerModel.music {
+                    ForEach(0..<3, id: \.self) { index in
+                        let emptyTimeInterval: TimeInterval = 5999.0
+                        if music.markers[index] != emptyTimeInterval {
+                            playerModel.markerButton(for: music.markers[index])
+                        } else {
+                            playerModel.addMarkerButton(index: index)
+                        }
                     }
                 }
             }
             .padding(.bottom, 8)
             
         }
-    }
-    
-    private func addMarkerButton(index: Int) -> some View {
-        Button(action: {
-            addMarker(at: index)
-        }) {
-            Text("추가")
-                .font(.title3)
-                .foregroundColor(.white)
-                .frame(width: 360, height: 60)
-                .background(Color.buttonDarkGray)
-                .cornerRadius(12)
-        }
-    }
-    
-    private func addMarker(at index: Int) {
-        guard let audioPlayer = audioPlayer else { return }
-        
-        let newMarker = audioPlayer.currentTime
-        if music.markers.count > index {
-            music.markers[index] = newMarker
-        } else {
-            music.markers.append(newMarker)
-        }
-        
-        do {
-            try modelContext.save()
-        } catch {
-            print("Failed to save context: \(error.localizedDescription)")
-        }
-    }
-    
-    @ViewBuilder
-    private func markerButton(for marker: TimeInterval) -> some View {
-        Button(action: {
-            moveToMarker(marker)
-        }) {
-            Text(formattedTime(marker))
-                .font(.title3)
-                .italic()
-                .foregroundColor(.black)
-                .frame(width: 360, height: 60)
-                .background(Color.primaryYellow)
-                .cornerRadius(12)
-        }
-    }
-    
-    private func moveToMarker(_ marker: TimeInterval) {
-        self.audioPlayer?.currentTime = marker
-        self.progress = CGFloat(marker / self.duration)
-        self.formattedProgress = self.formattedTime(marker)
-        audioPlayer?.play()
-        isPlaying = true
-    }
-    
-    private func formattedTime(_ time: TimeInterval) -> String {
-        let formatter = DateComponentsFormatter()
-        formatter.allowedUnits = [.minute, .second]
-        formatter.unitsStyle = .positional
-        formatter.zeroFormattingBehavior = [.pad]
-        return formatter.string(from: time)!
-    }
-    
-    /// 배속 조절 기능
-    private func decreasePlaybackRate() {
-        if self.playbackRate > 0.5 {
-            self.playbackRate -= 0.1
-            self.updateAudioPlayer()
-        }
-    }
-    
-    private func increasePlaybackRate() {
-        if self.playbackRate < 2.0 {
-            self.playbackRate += 0.1
-            self.updateAudioPlayer()
-        }
-    }
-    
-    private func updateAudioPlayer() {
-        guard let audioPlayer = audioPlayer else { return }
-        audioPlayer.rate = playbackRate
-        
-    }
-    
-    private func updateAudioPlayer(with time: TimeInterval) {
-        guard let audioPlayer = audioPlayer else { return }
-        audioPlayer.currentTime = time
-    }
-    
-    /// 음원 재생, 조작, 초기화
-    private func initAudioPlayer() {
-        let formatter = DateComponentsFormatter()
-        formatter.allowedUnits = [.minute, .second]
-        formatter.unitsStyle = .positional
-        formatter.zeroFormattingBehavior = [.pad]
-        
-        print("Attempting to load file at path: \(music.path)")
-        
-        // 파일 존재 여부 확인
-        guard FileManager.default.fileExists(atPath: music.path.path) else {
-            print("File not found at path: \(music.path)")
-            return
-        }
-        
-        do {
-            // AVAudioSession 설정
-            try AVAudioSession.sharedInstance().setCategory(.playback, mode: .default, options: [])
-            try AVAudioSession.sharedInstance().setActive(true)
-            
-            // AVAudioPlayer 초기화
-            self.audioPlayer = try AVAudioPlayer(contentsOf: music.path)
-            guard let audioPlayer = self.audioPlayer else {
-                print("Failed to initialize audio player")
-                return
-            }
-            
-            // 오디오 플레이어 준비 및 속성 설정
-            audioPlayer.prepareToPlay()
-            audioPlayer.enableRate = true
-            
-            // 포맷된 길이 설정
-            formattedDuration = formatter.string(from: audioPlayer.duration) ?? "0:00"
-            duration = audioPlayer.duration
-            
-            // 타이머 설정
-            Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true) { _ in
-                if !audioPlayer.isPlaying {
-                    self.isPlaying = false
-                }
-                
-                if !self.isDragging {
-                    self.currentTime = audioPlayer.currentTime
-                    self.progress = audioPlayer.duration > 0 ? Double(audioPlayer.currentTime / audioPlayer.duration) : 0
-                    self.formattedProgress = self.formattedTime(audioPlayer.currentTime)
-                }
-            }
-        } catch {
-            print("Error initializing audio player: \(error.localizedDescription)")
-        }
-    }
-    
-    private func togglePlayback() {
-        if let audioPlayer = audioPlayer {
-            if self.isPlaying {
-                audioPlayer.pause()
-            } else {
-                audioPlayer.play()
-            }
-            self.isPlaying.toggle()
-        }
-    }
-    
-    /// 음원 5초 앞으로 뒤로 가기 기능
-    private func seekToTime(to time: TimeInterval) {
-        guard let player = audioPlayer else { return }
-        player.currentTime = time
-        progress = CGFloat(time / player.duration)
-        formattedProgress = formattedTime(time)
-    }
-    
-    private func backward5Sec() {
-        guard let player = audioPlayer else { return }
-        let newTime = max(player.currentTime - 5, 0)
-        seekToTime(to: newTime)
-        // 제어 센터 업데이트 코드 추가
-    }
-    
-    private func forward5Sec() {
-        guard let player = audioPlayer else { return }
-        let newTime = min(player.currentTime + 5, player.duration)
-        seekToTime(to: newTime)
-        // 제어 센터 업데이트 코드 추가
     }
     
 }

--- a/DancingMarker/WatchDancingMarker Watch App/View/WatchMusicListView.swift
+++ b/DancingMarker/WatchDancingMarker Watch App/View/WatchMusicListView.swift
@@ -3,6 +3,8 @@ import SwiftUI
 struct WatchMusicListView: View {
     
     @Environment(WatchNavigationManager.self) var navigationManager
+    @EnvironmentObject var viewModel: WatchViewModel
+
     let columns = [ GridItem(.flexible()) ]
     
     let tempMusic = ["NewJeans-SuperNatural", "Music2", "Music3", "Music4"]
@@ -28,7 +30,3 @@ struct WatchMusicListView: View {
         }
     }
 }
-
-//#Preview {
-//    WatchMusicListView()
-//}

--- a/DancingMarker/WatchDancingMarker Watch App/View/WatchPlayingMarkerView.swift
+++ b/DancingMarker/WatchDancingMarker Watch App/View/WatchPlayingMarkerView.swift
@@ -2,67 +2,72 @@ import SwiftUI
 
 struct WatchPlayingMarkerView: View {
     
+    @EnvironmentObject var viewModel: WatchViewModel
+    
     var body: some View {
         
         HStack{
             // MARK: 마커 1
             ZStack {
                 Rectangle()
-                    .fill(Color.gray.opacity(0.2)) // 마커 추가가 되었다면 ? .yellow : Color.gray.opacity(0.2)
+                    .fill(viewModel.markers[0] == "99:59" ? Color.gray.opacity(0.2) : .yellow) // 마커 추가가 되었다면 ? .yellow : Color.gray.opacity(0.2)
                     .cornerRadius(4)
                     .frame(height: 52)
                 
                 VStack {
                     Image(systemName: "shield.fill")
-                    
-                    Text("추가") // 마커 추가가 되었다면 ? 마커 시간 : "추가"
+                    Text(viewModel.markers[0] == "99:59" ? "추가" : viewModel.markers[0]) // 마커 추가가 되었다면 ? 마커 시간 : "추가"
                 }
             }
             .onTapGesture {
-                print("마커 추가 #")
-                // 첫번째 마커 추가 기능이 들어가면 됩니다.
+                if viewModel.markers[0] == "99:59"{
+                    viewModel.connectivityManager.sendMarkerSaveToIOS(0)
+                } else {
+                    viewModel.connectivityManager.sendMarkerPlayToIOS(0)
+                }
             }
             
             // MARK: 마커 2
             ZStack {
                 Rectangle()
-                    .fill(Color.gray.opacity(0.2)) // 마커 추가가 되었다면 ? .yellow : Color.gray.opacity(0.2)
+                    .fill(viewModel.markers[1] == "99:59" ? Color.gray.opacity(0.2) : .yellow) // 마커 추가가 되었다면 ? .yellow : Color.gray.opacity(0.2)
                     .cornerRadius(4)
                     .frame(height: 52)
                 
                 VStack {
                     Image(systemName: "shield.fill")
-                    
-                    Text("추가")  // 마커 추가가 되었다면 ? 마커 시간 : "추가"
+                    Text(viewModel.markers[1] == "99:59" ? "추가" : viewModel.markers[1]) // 마커 추가가 되었다면 ? 마커 시간 : "추가"
                 }
             }
             .onTapGesture {
-                print("마커 추가 ##")
-                // 첫번째 마커 추가 기능이 들어가면 됩니다.
+                if viewModel.markers[1] == "99:59"{
+                    viewModel.connectivityManager.sendMarkerSaveToIOS(1)
+                } else {
+                    viewModel.connectivityManager.sendMarkerPlayToIOS(1)
+                }
             }
             
             // MARK: 마커 3
             ZStack {
                 Rectangle()
-                    .fill(Color.gray.opacity(0.2)) // 마커 추가가 되었다면 ? .yellow : Color.gray.opacity(0.2)
+                    .fill(viewModel.markers[2] == "99:59" ? Color.gray.opacity(0.2) : .yellow) // 마커 추가가 되었다면 ? .yellow : Color.gray.opacity(0.2)
                     .cornerRadius(4)
                     .frame(height: 52)
                 
                 VStack {
                     Image(systemName: "shield.fill")
-                    
-                    Text("추가")  // 마커 추가가 되었다면 ? 마커 시간 : "추가"
+                    Text(viewModel.markers[2] == "99:59" ? "추가" : viewModel.markers[2]) // 마커 추가가 되었다면 ? 마커 시간 : "추가"
                 }
             }
             .onTapGesture {
-                print("마커 추가 ###")
-                // 첫번째 마커 추가 기능이 들어가면 됩니다.
+                if viewModel.markers[2] == "99:59"{
+                    viewModel.connectivityManager.sendMarkerSaveToIOS(2)
+                } else {
+                    viewModel.connectivityManager.sendMarkerPlayToIOS(2)
+                }
+                
             }
         }
         .padding(.bottom)
     }
-}
-
-#Preview {
-    WatchPlayingMarkerView()
 }

--- a/DancingMarker/WatchDancingMarker Watch App/View/WatchPlayingView.swift
+++ b/DancingMarker/WatchDancingMarker Watch App/View/WatchPlayingView.swift
@@ -4,6 +4,8 @@ import SwiftUI
 struct WatchPlayingView: View {
     
     @Environment(WatchNavigationManager.self) var navigationManager
+    @EnvironmentObject var viewModel: WatchViewModel
+    
     @State var showMarkerListOverlay: Bool = false
     
     @State var progress: Double = 0.25 // 현재 진행 상황을 나타내는 변수
@@ -30,9 +32,7 @@ struct WatchPlayingView: View {
                         .cornerRadius(4)
                         .frame(height: 35)
                     Button(action:{
-                        print("현재 노래를 5초전으로 돌립니다.")
-                        // 현재 노래 5초 뒤로 가는 기능
-                        
+                        viewModel.playBackward()
                     }, label:{
                         Image(systemName: "gobackward.5")
                             .resizable()
@@ -51,8 +51,7 @@ struct WatchPlayingView: View {
                         .frame(width: 42, height: 42)
                     
                     Button(action: {
-                        print("현재 노래 재생 & 일시정지")
-                        // 현재 노래 재생/일시정지 기능 구현
+                        viewModel.playToggle()
                     }, label: {
                         Image(systemName: "play.fill") // 재생 on/off에 따라 이미지 변경
                             .resizable()
@@ -69,9 +68,7 @@ struct WatchPlayingView: View {
                         .frame(height: 35)
                     
                     Button(action:{
-                        print("현재 노래를 5초 후로 돌립니다.")
-                        // 현재 노래 5초 앞으로 가는 기능
-                        
+                        viewModel.playForward()
                     }, label:{
                         Image(systemName: "goforward.5")
                             .resizable()

--- a/DancingMarker/WatchDancingMarker Watch App/WatchDancingMarkerApp.swift
+++ b/DancingMarker/WatchDancingMarker Watch App/WatchDancingMarkerApp.swift
@@ -9,9 +9,13 @@ import SwiftUI
 
 @main
 struct WatchDancingMarker_Watch_AppApp: App {
+    
+    @StateObject var viewModel = WatchViewModel(connectivityManager: WatchConnectivityManager())
+
     var body: some Scene {
         WindowGroup {
             ContentView()
+                .environmentObject(viewModel)
         }
     }
 }

--- a/DancingMarker/WatchDancingMarker Watch App/WatchViewModel.swift
+++ b/DancingMarker/WatchDancingMarker Watch App/WatchViewModel.swift
@@ -1,0 +1,54 @@
+//
+//  ViewModel.swift
+//  WatchDancingMarker Watch App
+//
+//  Created by 변준섭 on 7/16/24.
+//
+import SwiftUI
+
+class WatchViewModel: ObservableObject {
+    
+    var music: Music?
+    
+    var connectivityManager: WatchConnectivityManager
+    @Published var markers: [String] = ["99:59", "99:59", "99:59"]
+    
+    init(connectivityManager: WatchConnectivityManager) {
+        self.connectivityManager = connectivityManager
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(updateMarkers(_:)),
+            name: .sendMarkers,
+            object: nil
+        )
+    }
+    convenience init() {
+           self.init(connectivityManager: WatchConnectivityManager())
+       }
+    
+    @objc func updateMarkers(_ notification: Notification) {
+        if let markers = notification.object as? [TimeInterval] {
+            // 수신한 markers 데이터를 처리하는 로직
+            self.markers = markers.compactMap { self.formattedTime($0) }
+        }
+    }
+    
+    func playToggle() {
+        connectivityManager.sendPlayToggleToIOS()
+    }
+    
+    func playForward() {
+        connectivityManager.sendForwardToIOS()
+    }
+    func playBackward() {
+        connectivityManager.sendBackwardToIOS()
+    }
+    
+    func formattedTime(_ time: TimeInterval) -> String {
+        let formatter = DateComponentsFormatter()
+        formatter.allowedUnits = [.minute, .second]
+        formatter.unitsStyle = .positional
+        formatter.zeroFormattingBehavior = [.pad]
+        return formatter.string(from: time)!
+    }
+}


### PR DESCRIPTION
- WatchOS 재생, 5초 앞/뒤 구현
- WatchOS 마커 기록, 마커 재생 구현

위 2 기능 구현하는 과정에서
- Player 를 독립적으로 관리하는 PlayerModel 추가 : 추후 Nowplaying 과 같이 현재 재생 중인 정보를 가져오는 과정에서 사용될 예정
- WatchConnectivity 에서 받아온 정보를 토대로 View 에 전달하는 WatchViewModel 추가

추가적으로 고민해야 할 부분
- 음악을 켠 채로 다른 음악을 골랐을 때, 중복적으로 음악이 재생됨. 우리와 반대의 문제를 겪고 있는 상황 링크 https://stackoverflow.com/questions/17438030/ios-avaudioplayer-can-it-only-play-one-file
- WatchOS에 어떻게 음악 리스트를 갖게 할건가? 1. 음악 리스트를 워치 OS 내에 따로 SwiftData 저장하게 할 것인지 2. 어차피 워치 앱만 켰을 때도, ios 앱이 백그라운드로 켜지긴 해야 하니, 워치 앱이 켜지면 자동으로 ios 앱이 백그라운드에서도 실행 실행 후 리스트들을 실시간으로 받아와서 그릴 것인지 고민중