### PR TITLE
[FEAT] #98 MusicEditView 구현

### DIFF
--- a/DancingMarker/DancingMarker.xcodeproj/project.pbxproj
+++ b/DancingMarker/DancingMarker.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		51675E282CA2F0E800D8D08F /* Secrets.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 51675E272CA2F0E800D8D08F /* Secrets.xcconfig */; };
 		51675E292CA2F0E800D8D08F /* Secrets.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 51675E272CA2F0E800D8D08F /* Secrets.xcconfig */; };
 		516D95502D533F5D00AA8EAA /* TextMarquee.swift in Sources */ = {isa = PBXBuildFile; fileRef = 516D954F2D533F5D00AA8EAA /* TextMarquee.swift */; };
+		51EF633C2D99716400967EC8 /* View+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51EF633B2D99715C00967EC8 /* View+.swift */; };
 		901BF9812C29804A00C02FF9 /* DancingMarkerApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 901BF9802C29804A00C02FF9 /* DancingMarkerApp.swift */; };
 		901BF9852C29804B00C02FF9 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 901BF9842C29804B00C02FF9 /* Assets.xcassets */; };
 		901BF9882C29804B00C02FF9 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 901BF9872C29804B00C02FF9 /* Preview Assets.xcassets */; };
@@ -99,6 +100,7 @@
 		512224C12D8C68C900AABC82 /* SelectGalleryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectGalleryView.swift; sourceTree = "<group>"; };
 		51675E272CA2F0E800D8D08F /* Secrets.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Secrets.xcconfig; sourceTree = "<group>"; };
 		516D954F2D533F5D00AA8EAA /* TextMarquee.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextMarquee.swift; sourceTree = "<group>"; };
+		51EF633B2D99715C00967EC8 /* View+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+.swift"; sourceTree = "<group>"; };
 		51FD01772C3BC6B1003F99B5 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		901BF97D2C29804A00C02FF9 /* DancingMarker.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = DancingMarker.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		901BF9802C29804A00C02FF9 /* DancingMarkerApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DancingMarkerApp.swift; sourceTree = "<group>"; };
@@ -226,6 +228,7 @@
 		512224BE2D8C682E00AABC82 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				51EF633B2D99715C00967EC8 /* View+.swift */,
 				512224BF2D8C685500AABC82 /* UIImage+.swift */,
 			);
 			path = Extensions;
@@ -522,6 +525,7 @@
 				512224C02D8C685E00AABC82 /* UIImage+.swift in Sources */,
 				90A4722F2C450867008577A2 /* WCManager.swift in Sources */,
 				5104B7F62C3D67F2008E10E8 /* Music.swift in Sources */,
+				51EF633C2D99716400967EC8 /* View+.swift in Sources */,
 				90E28F562C2D092E009098BE /* NavigationManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/DancingMarker/DancingMarker.xcodeproj/project.pbxproj
+++ b/DancingMarker/DancingMarker.xcodeproj/project.pbxproj
@@ -689,7 +689,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2025032113;
 				DEVELOPMENT_ASSET_PATHS = "\"DancingMarker/Preview Content\"";
 				DEVELOPMENT_TEAM = 2U3B7G3F2A;
 				ENABLE_PREVIEWS = YES;
@@ -710,7 +710,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.test.DancingMarker;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -733,7 +733,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2025032113;
 				DEVELOPMENT_ASSET_PATHS = "\"DancingMarker/Preview Content\"";
 				DEVELOPMENT_TEAM = 2U3B7G3F2A;
 				ENABLE_PREVIEWS = YES;
@@ -754,7 +754,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.test.DancingMarker;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/DancingMarker/DancingMarker.xcodeproj/project.pbxproj
+++ b/DancingMarker/DancingMarker.xcodeproj/project.pbxproj
@@ -30,6 +30,8 @@
 		510D90312CA2F1C8002E82CC /* PlayingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 510D902E2CA2F1C8002E82CC /* PlayingView.swift */; };
 		510D90322CA2F1C8002E82CC /* TipPopupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 510D902F2CA2F1C8002E82CC /* TipPopupView.swift */; };
 		510D90352CA2F1C8002E82CC /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 510D90332CA2F1C8002E82CC /* ContentView.swift */; };
+		512224C02D8C685E00AABC82 /* UIImage+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 512224BF2D8C685500AABC82 /* UIImage+.swift */; };
+		512224C22D8C68D100AABC82 /* SelectGalleryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 512224C12D8C68C900AABC82 /* SelectGalleryView.swift */; };
 		51675E282CA2F0E800D8D08F /* Secrets.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 51675E272CA2F0E800D8D08F /* Secrets.xcconfig */; };
 		51675E292CA2F0E800D8D08F /* Secrets.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 51675E272CA2F0E800D8D08F /* Secrets.xcconfig */; };
 		516D95502D533F5D00AA8EAA /* TextMarquee.swift in Sources */ = {isa = PBXBuildFile; fileRef = 516D954F2D533F5D00AA8EAA /* TextMarquee.swift */; };
@@ -93,6 +95,8 @@
 		510D902E2CA2F1C8002E82CC /* PlayingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayingView.swift; sourceTree = "<group>"; };
 		510D902F2CA2F1C8002E82CC /* TipPopupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TipPopupView.swift; sourceTree = "<group>"; };
 		510D90332CA2F1C8002E82CC /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		512224BF2D8C685500AABC82 /* UIImage+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+.swift"; sourceTree = "<group>"; };
+		512224C12D8C68C900AABC82 /* SelectGalleryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectGalleryView.swift; sourceTree = "<group>"; };
 		51675E272CA2F0E800D8D08F /* Secrets.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Secrets.xcconfig; sourceTree = "<group>"; };
 		516D954F2D533F5D00AA8EAA /* TextMarquee.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextMarquee.swift; sourceTree = "<group>"; };
 		51FD01772C3BC6B1003F99B5 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -194,6 +198,7 @@
 		510D902A2CA2F1C8002E82CC /* Main */ = {
 			isa = PBXGroup;
 			children = (
+				512224C12D8C68C900AABC82 /* SelectGalleryView.swift */,
 				510D90272CA2F1C8002E82CC /* MusicEditView.swift */,
 				510D90282CA2F1C8002E82CC /* MusicListView.swift */,
 				510D90292CA2F1C8002E82CC /* NowPlayingView.swift */,
@@ -216,6 +221,14 @@
 				510D90332CA2F1C8002E82CC /* ContentView.swift */,
 			);
 			path = Content;
+			sourceTree = "<group>";
+		};
+		512224BE2D8C682E00AABC82 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				512224BF2D8C685500AABC82 /* UIImage+.swift */,
+			);
+			path = Extensions;
 			sourceTree = "<group>";
 		};
 		513303FF2C4CD65400CC5F22 /* Resource */ = {
@@ -309,6 +322,7 @@
 		901BF97F2C29804A00C02FF9 /* DancingMarker */ = {
 			isa = PBXGroup;
 			children = (
+				512224BE2D8C682E00AABC82 /* Extensions */,
 				90E28F552C2D092E009098BE /* NavigationManager.swift */,
 				518D7F022CA2E24100612544 /* Application */,
 				518D7F042CA2E27B00612544 /* View */,
@@ -502,8 +516,10 @@
 				510D902B2CA2F1C8002E82CC /* MusicEditView.swift in Sources */,
 				510D902C2CA2F1C8002E82CC /* MusicListView.swift in Sources */,
 				510D902D2CA2F1C8002E82CC /* NowPlayingView.swift in Sources */,
+				512224C22D8C68D100AABC82 /* SelectGalleryView.swift in Sources */,
 				901BF9812C29804A00C02FF9 /* DancingMarkerApp.swift in Sources */,
 				902077082C464CB800988D2B /* PlayerModel.swift in Sources */,
+				512224C02D8C685E00AABC82 /* UIImage+.swift in Sources */,
 				90A4722F2C450867008577A2 /* WCManager.swift in Sources */,
 				5104B7F62C3D67F2008E10E8 /* Music.swift in Sources */,
 				90E28F562C2D092E009098BE /* NavigationManager.swift in Sources */,

--- a/DancingMarker/DancingMarker.xcodeproj/xcuserdata/woowonkang.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/DancingMarker/DancingMarker.xcodeproj/xcuserdata/woowonkang.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -7,7 +7,7 @@
 		<key>DancingMarker.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>0</integer>
+			<integer>1</integer>
 		</dict>
 		<key>WatchDancingMarker Watch App (Notification).xcscheme_^#shared#^_</key>
 		<dict>
@@ -17,7 +17,7 @@
 		<key>WatchDancingMarker Watch App.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>1</integer>
+			<integer>0</integer>
 		</dict>
 	</dict>
 </dict>

--- a/DancingMarker/DancingMarker/Extensions/UIImage+.swift
+++ b/DancingMarker/DancingMarker/Extensions/UIImage+.swift
@@ -1,0 +1,32 @@
+//
+//  UIImage+.swift
+//  DancingMarker
+//
+//  Created by Woowon Kang on 3/21/25.
+//
+
+import UIKit
+
+extension UIImage {
+    func croppedToSquare() -> UIImage? {
+        guard let cgImage = self.cgImage else { return nil }
+        
+        let width = CGFloat(cgImage.width)
+        let height = CGFloat(cgImage.height)
+        
+        let aspectRatio = width / height
+        var rect: CGRect
+        
+        if aspectRatio > 1 {
+            // 가로가 더 긴 경우 → 가운데를 기준으로 정방형으로 자르기
+            rect = CGRect(x: (width - height) / 2, y: 0, width: height, height: height)
+        } else {
+            // 세로가 더 긴 경우 → 가운데를 기준으로 정방형으로 자르기
+            rect = CGRect(x: 0, y: (height - width) / 2, width: width, height: width)
+        }
+        
+        guard let croppedCGImage = cgImage.cropping(to: rect) else { return nil }
+        
+        return UIImage(cgImage: croppedCGImage, scale: self.scale, orientation: self.imageOrientation)
+    }
+}

--- a/DancingMarker/DancingMarker/Extensions/View+.swift
+++ b/DancingMarker/DancingMarker/Extensions/View+.swift
@@ -1,0 +1,39 @@
+//
+//  View+.swift
+//  DancingMarker
+//
+//  Created by Woowon Kang on 3/30/25.
+//
+
+import SwiftUI
+
+struct SwipeBackModifier: UIViewControllerRepresentable {
+    func makeUIViewController(context: Context) -> UIViewController {
+        let viewController = UIViewController()
+        DispatchQueue.main.async {
+            if let navController = viewController.navigationController {
+                navController.interactivePopGestureRecognizer?.delegate = context.coordinator
+                navController.interactivePopGestureRecognizer?.isEnabled = true
+            }
+        }
+        return viewController
+    }
+    
+    func updateUIViewController(_ uiViewController: UIViewController, context: Context) { }
+    
+    func makeCoordinator() -> Coordinator {
+        Coordinator()
+    }
+    
+    class Coordinator: NSObject, UIGestureRecognizerDelegate {
+        func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+            return true
+        }
+    }
+}
+
+extension View {
+    func enableSwipeBack() -> some View {
+        self.background(SwipeBackModifier())
+    }
+}

--- a/DancingMarker/DancingMarker/NavigationManager.swift
+++ b/DancingMarker/DancingMarker/NavigationManager.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 enum PathType: Hashable {
     case musicList
-    case musicedit
+    case musicedit(fileURL: URL, didSaveMusic: Bool)  
     case playing
     case nowplaying
 }
@@ -20,13 +20,10 @@ extension PathType {
         switch self {
         case .musicList:
             MusicListView()
-            
-        case .musicedit:
-            MusicEditView()
-            
+        case .musicedit(let fileURL, let didSaveMusic):
+            MusicEditView(fileURL: fileURL, didSaveMusic: .constant(didSaveMusic))
         case .playing:
             PlayingView()
-            
         case .nowplaying:
             NowPlayingView()
         }

--- a/DancingMarker/DancingMarker/Resource/Assets.xcassets/editViewAlbumGray.colorset/Contents.json
+++ b/DancingMarker/DancingMarker/Resource/Assets.xcassets/editViewAlbumGray.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x1D",
+          "green" : "0x1C",
+          "red" : "0x1C"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x1D",
+          "green" : "0x1C",
+          "red" : "0x1C"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/DancingMarker/DancingMarker/Resource/Assets.xcassets/editViewBGBlack.colorset/Contents.json
+++ b/DancingMarker/DancingMarker/Resource/Assets.xcassets/editViewBGBlack.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x12",
+          "green" : "0x12",
+          "red" : "0x12"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x12",
+          "green" : "0x12",
+          "red" : "0x12"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/DancingMarker/DancingMarker/View/Main/MusicEditView.swift
+++ b/DancingMarker/DancingMarker/View/Main/MusicEditView.swift
@@ -18,6 +18,7 @@ struct MusicEditView: View {
     @Query var musicList: [Music] = []
     @Binding var didSaveMusic: Bool
     
+    @State private var selectedImgData: Data?
     @State private var title: String = ""
     @State private var artist: String = ""
     @State private var albumArt: UIImage? = nil
@@ -141,8 +142,13 @@ struct MusicEditView: View {
                 }
             }}
         .sheet(isPresented: $isImagePickerPresented) {
-            // ImagePicker 구현 (예: ImagePicker(selectedImage: $albumArt))
-            Text("ImagePicker 구현 필요")
+            // ImagePicker 구현
+            SelectGalleryView(selectedImgData: $selectedImgData)
+        }
+        .onChange(of: selectedImgData) {
+            if let data = selectedImgData, let image = UIImage(data: data) {
+                albumArt = image 
+            }
         }
         .onAppear {
             Task {

--- a/DancingMarker/DancingMarker/View/Main/MusicEditView.swift
+++ b/DancingMarker/DancingMarker/View/Main/MusicEditView.swift
@@ -6,22 +6,231 @@
 //
 
 import SwiftUI
+import SwiftData
+import AVFoundation
 
 struct MusicEditView: View {
     @Environment(NavigationManager.self) var navigationManager
+    @Environment(\.modelContext) private var modelContext
+    @Environment(\.dismiss) private var dismiss
+    @EnvironmentObject var playerModel: PlayerModel
+    let fileURL: URL  // 파일 URL
+    @Query var musicList: [Music] = []
+    @Binding var didSaveMusic: Bool
+    
+    @State private var title: String = ""
+    @State private var artist: String = ""
+    @State private var albumArt: UIImage? = nil
+    @State private var isImagePickerPresented: Bool = false
     
     var body: some View {
-        VStack{
-            Text("여기는 MusicEditView.")
-
-            Button("Go to MusicListView") {
-                navigationManager.push(to: .musicList)
-            }.buttonBorderShape(.roundedRectangle)
+        ZStack {
+            Color.editViewBGBlack.edgesIgnoringSafeArea(.all)
+            
+            VStack {
+                VStack {
+                    if let albumArt = albumArt {
+                        Image(uiImage: albumArt)
+                            .resizable()
+                            .scaledToFit()
+                            .frame(width: 160, height: 160)
+                            .cornerRadius(12)
+                    } else {
+                        RoundedRectangle(cornerRadius: 12)
+                            .foregroundStyle(.editViewAlbumGray)  // 배경 색 적용
+                            .frame(width: 160, height: 160)
+                            .overlay {
+                                Image(systemName: "music.note")
+                                    .resizable()
+                                    .scaledToFit()
+                                    .frame(width: 40, height: 40)  // 사이즈 조정
+                                    .foregroundStyle(.white)  // 흰색 아이콘
+                            }
+                        
+                    }
+                    Button("커버이미지 변경하기") {
+                        isImagePickerPresented = true
+                    }
+                    .font(.caption)
+                    .foregroundStyle(.markerPurple)
+                    .underline(true, color: .markerPurple)
+                    .buttonStyle(.plain)
+                }
+                .padding(.top, 67)
+                .padding(.bottom, 43)
+                
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("음원 제목")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)  // 제목 스타일
+                    
+                    HStack {
+                        TextField("음원의 제목을 입력해주세요", text: $title)
+                            .frame(height: 34)
+                            .background(Color.clear)
+                            .autocorrectionDisabled(true)
+                            .textInputAutocapitalization(.never)
+                        
+                        if !title.isEmpty {
+                            Button(action: { title = "" }) {
+                                Image(systemName: "xmark.circle.fill")
+                                    .foregroundStyle(.gray)
+                            }
+                            .buttonStyle(.plain)
+                        }
+                    }
+                }
+                .padding(.bottom, 16)
+                
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("아티스트")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)  // 제목 스타일
+                    
+                    HStack {
+                        TextField("아티스트 정보를 입력해주세요", text: $artist)
+                            .frame(height: 34)
+                            .background(Color.clear)
+                            .autocorrectionDisabled(true)
+                            .textInputAutocapitalization(.never)
+                        
+                        if !artist.isEmpty {
+                            Button(action: { artist = "" }) {
+                                Image(systemName: "xmark.circle.fill")
+                                    .foregroundStyle(.gray)
+                            }
+                            .buttonStyle(.plain)
+                        }
+                    }
+                    
+                }
+                
+                Spacer()
+                
+                Button("저장하기") {
+                    Task {
+                        await addMusic(from: fileURL)
+                        didSaveMusic = true  // 저장 여부 설정
+                        dismiss()  // Sheet 닫기 (FileImporter 열리지 않음)
+                    }
+                }
+                .fontWeight(.bold)
+                .frame(height: 49)
+                .frame(maxWidth: .infinity)
+                .background(title.isEmpty || artist.isEmpty ? Color.gray.opacity(0.3) : Color.accentColor)
+                .foregroundStyle(title.isEmpty || artist.isEmpty ? Color.white : Color.black)
+                .cornerRadius(12)
+                .disabled(title.isEmpty || artist.isEmpty)  // ✅ 비활성화 상태 적용
+                .padding(.bottom, 53)
+                
+            }
+            .padding(.horizontal, 16)
+            .navigationTitle("음악 수정하기")
+            .navigationBarTitleDisplayMode(.inline)
+            .navigationBarBackButtonHidden(true)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    HStack {
+                        Image(systemName: "chevron.left").bold()
+                        Text("뒤로가기")
+                    }
+                    .foregroundStyle(.accent)
+                    .onTapGesture {
+                        dismiss()
+                    }
+                }
+            }}
+        .sheet(isPresented: $isImagePickerPresented) {
+            // ImagePicker 구현 (예: ImagePicker(selectedImage: $albumArt))
+            Text("ImagePicker 구현 필요")
+        }
+        .onAppear {
+            Task {
+                do {
+                    let success = fileURL.startAccessingSecurityScopedResource()  // ✅ 반환 값을 변수에 저장
+                    if !success {
+                        print("보안 접근 권한을 얻는 데 실패했습니다.")
+                    }
+                    defer { fileURL.stopAccessingSecurityScopedResource() }
+                    
+                    let (metaTitle, metaArtist, metaAlbumArtData) = try await fetchMusicMetadata(from: fileURL)
+                    
+                    await MainActor.run {
+                        if title.isEmpty { title = metaTitle }
+                        if artist.isEmpty { artist = metaArtist }
+                        if albumArt == nil, let data = metaAlbumArtData, let image = UIImage(data: data) {
+                            albumArt = image
+                        }
+                    }
+                } catch {
+                    print("메타데이터 로드 실패: \(error.localizedDescription)")
+                }
+            }
         }
     }
-}
-
-#Preview {
-    MusicEditView()
-        .environment(NavigationManager())
+    
+    private func addMusic(from url: URL) async {
+        guard url.startAccessingSecurityScopedResource() else {
+            print("Failed to start accessing security scoped resource at \(url)")
+            return
+        }
+        
+        do {
+            // AVAsset에서 메타데이터를 가져오되, 사용자 입력을 우선적으로 사용할 예정
+            let (metadataTitle, metadataArtist, metadataAlbumArt) = try await fetchMusicMetadata(from: url)
+            
+            // 사용자가 입력한 값이 있다면 그것을, 아니면 메타데이터를 사용하도록 결정
+            let finalTitle = title.isEmpty ? metadataTitle : title
+            let finalArtist = artist.isEmpty ? metadataArtist : artist
+            let finalAlbumArt: Data?
+            if let userAlbumArt = albumArt {
+                finalAlbumArt = userAlbumArt.pngData()
+            } else {
+                finalAlbumArt = metadataAlbumArt
+            }
+            
+            let documentsDirectory = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+            let uniqueFileURL = documentsDirectory.appendingUniquePathComponent(url.lastPathComponent)
+            
+            try FileManager.default.copyItem(at: url, to: uniqueFileURL)
+            
+            let newMusic = Music(
+                title: finalTitle,
+                artist: finalArtist,
+                fileName: uniqueFileURL.lastPathComponent,
+                markers: [-1, -1, -1],
+                albumArt: finalAlbumArt
+            )
+            
+            modelContext.insert(newMusic)
+            try modelContext.save()
+            
+            playerModel.sendMusicListToWatch(with: musicList)
+        } catch {
+            print("Failed to add music: \(error.localizedDescription)")
+        }
+    }
+    
+    private func fetchMusicMetadata(from url: URL) async throws -> (String, String, Data?) {
+        let asset = AVAsset(url: url)
+        let metadata = try await asset.load(.commonMetadata)
+        
+        var title: String = "Unknown Title"
+        var artist: String = "Unknown Artist"
+        var albumArt: Data? = nil
+        
+        for item in metadata {
+            if item.commonKey == .commonKeyTitle {
+                title = try await item.load(.stringValue) ?? "Unknown Title"
+            }
+            if item.commonKey == .commonKeyArtist {
+                artist = try await item.load(.stringValue) ?? "Unknown Artist"
+            }
+            if item.commonKey == .commonKeyArtwork {
+                albumArt = try await item.load(.dataValue)
+            }
+        }
+        
+        return (title, artist, albumArt)
+    }
 }

--- a/DancingMarker/DancingMarker/View/Main/MusicEditView.swift
+++ b/DancingMarker/DancingMarker/View/Main/MusicEditView.swift
@@ -10,12 +10,17 @@ import SwiftData
 import AVFoundation
 
 struct MusicEditView: View {
-    @Environment(NavigationManager.self) var navigationManager
     @Environment(\.modelContext) private var modelContext
     @Environment(\.dismiss) private var dismiss
     @EnvironmentObject var playerModel: PlayerModel
-    let fileURL: URL  // 파일 URL
+    
     @Query var musicList: [Music] = []
+    
+    // 편집 모드: 기존 음원 수정 시 music이 전달되고,
+    // 새 음원 추가 시에는 fileURL이 전달됩니다.
+    let music: Music?
+    let fileURL: URL?
+    // 새 음원 추가용 binding (기존 음원 수정 시엔 사용하지 않음)
     @Binding var didSaveMusic: Bool
     
     @State private var selectedImgData: Data?
@@ -23,6 +28,25 @@ struct MusicEditView: View {
     @State private var artist: String = ""
     @State private var albumArt: UIImage? = nil
     @State private var isImagePickerPresented: Bool = false
+    
+    init(music: Music) {
+        self.music = music
+        self.fileURL = nil
+        // 기존 음원 수정에서는 didSaveMusic binding은 사용하지 않음
+        self._didSaveMusic = .constant(false)
+        _title = State(initialValue: music.title)
+        _artist = State(initialValue: music.artist)
+        if let artData = music.albumArt, let image = UIImage(data: artData) {
+            _albumArt = State(initialValue: image)
+        }
+    }
+    
+    init(fileURL: URL, didSaveMusic: Binding<Bool>) {
+        self.music = nil
+        self.fileURL = fileURL
+        self._didSaveMusic = didSaveMusic
+        // 초기값은 onAppear에서 fileURL 기반으로 불러옵니다.
+    }
     
     var body: some View {
         ZStack {
@@ -49,6 +73,7 @@ struct MusicEditView: View {
                             }
                         
                     }
+                    
                     Button("커버이미지 변경하기") {
                         isImagePickerPresented = true
                     }
@@ -105,14 +130,26 @@ struct MusicEditView: View {
                     }
                     
                 }
-                
                 Spacer()
                 
                 Button("저장하기") {
                     Task {
-                        await addMusic(from: fileURL)
-                        didSaveMusic = true  // 저장 여부 설정
-                        dismiss()  // Sheet 닫기 (FileImporter 열리지 않음)
+                        if let existingMusic = music {
+                            // 기존 음원 수정: Music 객체 업데이트
+                            existingMusic.title = title
+                            existingMusic.artist = artist
+                            existingMusic.albumArt = albumArt?.pngData()
+                            do {
+                                try modelContext.save()
+                            } catch {
+                                print("음원 수정 실패: \(error.localizedDescription)")
+                            }
+                        } else if let fileURL = fileURL {
+                            // 새 음원 추가: 파일 복사 후 새 Music 객체 생성
+                            await addMusic(from: fileURL)
+                            didSaveMusic = true
+                        }
+                        dismiss()
                     }
                 }
                 .fontWeight(.bold)
@@ -121,7 +158,7 @@ struct MusicEditView: View {
                 .background(title.isEmpty || artist.isEmpty ? Color.gray.opacity(0.3) : Color.accentColor)
                 .foregroundStyle(title.isEmpty || artist.isEmpty ? Color.white : Color.black)
                 .cornerRadius(12)
-                .disabled(title.isEmpty || artist.isEmpty)  // ✅ 비활성화 상태 적용
+                .disabled(title.isEmpty || artist.isEmpty) 
                 .padding(.bottom, 53)
                 
             }
@@ -142,7 +179,6 @@ struct MusicEditView: View {
                 }
             }}
         .sheet(isPresented: $isImagePickerPresented) {
-            // ImagePicker 구현
             SelectGalleryView(selectedImgData: $selectedImgData)
         }
         .onChange(of: selectedImgData) {
@@ -151,25 +187,20 @@ struct MusicEditView: View {
             }
         }
         .onAppear {
-            Task {
-                do {
-                    let success = fileURL.startAccessingSecurityScopedResource()  // ✅ 반환 값을 변수에 저장
-                    if !success {
-                        print("보안 접근 권한을 얻는 데 실패했습니다.")
-                    }
-                    defer { fileURL.stopAccessingSecurityScopedResource() }
-                    
-                    let (metaTitle, metaArtist, metaAlbumArtData) = try await fetchMusicMetadata(from: fileURL)
-                    
-                    await MainActor.run {
-                        if title.isEmpty { title = metaTitle }
-                        if artist.isEmpty { artist = metaArtist }
-                        if albumArt == nil, let data = metaAlbumArtData, let image = UIImage(data: data) {
-                            albumArt = image
+            if music == nil, let fileURL = fileURL {
+                Task {
+                    do {
+                        let (metaTitle, metaArtist, metaAlbumArtData) = try await fetchMusicMetadata(from: fileURL)
+                        await MainActor.run {
+                            if title.isEmpty { title = metaTitle }
+                            if artist.isEmpty { artist = metaArtist }
+                            if albumArt == nil, let data = metaAlbumArtData, let image = UIImage(data: data) {
+                                albumArt = image
+                            }
                         }
+                    } catch {
+                        print("메타데이터 로드 실패: \(error.localizedDescription)")
                     }
-                } catch {
-                    print("메타데이터 로드 실패: \(error.localizedDescription)")
                 }
             }
         }

--- a/DancingMarker/DancingMarker/View/Main/MusicEditView.swift
+++ b/DancingMarker/DancingMarker/View/Main/MusicEditView.swift
@@ -132,7 +132,8 @@ struct MusicEditView: View {
                 }
                 Spacer()
                 
-                Button("저장하기") {
+                Button(action: {
+                    guard !title.isEmpty, !artist.isEmpty else { return }
                     Task {
                         if let existingMusic = music {
                             // 기존 음원 수정: Music 객체 업데이트
@@ -151,15 +152,22 @@ struct MusicEditView: View {
                         }
                         dismiss()
                     }
+                }) {
+                    HStack {
+                        Spacer()
+                        Text("저장하기")
+                            .fontWeight(.bold)
+                        Spacer()
+                    }
+                    .frame(height: 49)
+                    .frame(maxWidth: .infinity)
+                    .background(title.isEmpty || artist.isEmpty ? Color.gray.opacity(0.3) : Color.accentColor)
+                    .foregroundColor(title.isEmpty || artist.isEmpty ? Color.white : Color.black)
+                    .cornerRadius(12)
+                    .padding(.bottom, 53)
                 }
-                .fontWeight(.bold)
-                .frame(height: 49)
-                .frame(maxWidth: .infinity)
-                .background(title.isEmpty || artist.isEmpty ? Color.gray.opacity(0.3) : Color.accentColor)
-                .foregroundStyle(title.isEmpty || artist.isEmpty ? Color.white : Color.black)
-                .cornerRadius(12)
-                .disabled(title.isEmpty || artist.isEmpty) 
-                .padding(.bottom, 53)
+                .buttonStyle(.plain)
+                .disabled(title.isEmpty || artist.isEmpty)
                 
             }
             .padding(.horizontal, 16)
@@ -168,10 +176,7 @@ struct MusicEditView: View {
             .navigationBarBackButtonHidden(true)
             .toolbar {
                 ToolbarItem(placement: .navigationBarLeading) {
-                    HStack {
-                        Image(systemName: "chevron.left").bold()
-                        Text("뒤로가기")
-                    }
+                    Text("취소하기")
                     .foregroundStyle(.accent)
                     .onTapGesture {
                         dismiss()

--- a/DancingMarker/DancingMarker/View/Main/MusicEditView.swift
+++ b/DancingMarker/DancingMarker/View/Main/MusicEditView.swift
@@ -93,7 +93,7 @@ struct MusicEditView: View {
                     HStack {
                         TextField("음원의 제목을 입력해주세요", text: $title)
                             .frame(height: 34)
-                            .background(Color.clear)
+                            .background(.clear)
                             .autocorrectionDisabled(true)
                             .textInputAutocapitalization(.never)
                         
@@ -128,7 +128,6 @@ struct MusicEditView: View {
                             .buttonStyle(.plain)
                         }
                     }
-                    
                 }
                 Spacer()
                 
@@ -168,7 +167,6 @@ struct MusicEditView: View {
                 }
                 .buttonStyle(.plain)
                 .disabled(title.isEmpty || artist.isEmpty)
-                
             }
             .padding(.horizontal, 16)
             .navigationTitle("음악 수정하기")

--- a/DancingMarker/DancingMarker/View/Main/MusicListView.swift
+++ b/DancingMarker/DancingMarker/View/Main/MusicListView.swift
@@ -184,6 +184,7 @@ struct MusicListView: View {
                     //     MusicEditView(fileURL: fileURL, didSaveMusic: $didSaveMusic)
                     // }
                 }
+                .id(selectedFileURL?.absoluteString ?? UUID().uuidString)
             }
         .edgesIgnoringSafeArea(.bottom)
     }

--- a/DancingMarker/DancingMarker/View/Main/MusicListView.swift
+++ b/DancingMarker/DancingMarker/View/Main/MusicListView.swift
@@ -159,9 +159,6 @@ struct MusicListView: View {
                             await addMusic(from: url)
                             didSaveMusic = true
                         }
-                        // MusicEditView를 띄우지 않음
-                        // selectedFileURL = url
-                        // isMusicEditViewPresented = true
                     }
                 case .failure(let error):
                     print("Failed to import file: \(error.localizedDescription)")
@@ -171,7 +168,6 @@ struct MusicListView: View {
                 if !didSaveMusic, selectedMusic == nil {
                     isFileImporterPresented = true  // 저장하지 않고 닫으면 FileImporter 다시 열기
                 }
-                // 초기화
                 selectedMusic = nil
             }) {
                 NavigationStack {
@@ -179,10 +175,6 @@ struct MusicListView: View {
                         // 기존 음원 수정
                         MusicEditView(music: selectedMusic)
                     }
-                    // 새 음원 추가용 MusicEditView 부분 제거
-                    // else if let fileURL = selectedFileURL {
-                    //     MusicEditView(fileURL: fileURL, didSaveMusic: $didSaveMusic)
-                    // }
                 }
                 .id(selectedFileURL?.absoluteString ?? UUID().uuidString)
             }
@@ -281,23 +273,35 @@ struct MusicListView: View {
         let asset = AVAsset(url: url)
         let metadata = try await asset.load(.commonMetadata)
         
-        var title: String = "Unknown Title"
-        var artist: String = "Unknown Artist"
+        var title: String? = nil
+        var artist: String? = nil
         var albumArt: Data? = nil
         
         for item in metadata {
-            if item.commonKey == .commonKeyTitle {
-                title = try await item.load(.stringValue) ?? "Unknown Title"
+            if item.commonKey == .commonKeyTitle,
+               let loadedTitle = try await item.load(.stringValue) {
+                title = loadedTitle
             }
-            if item.commonKey == .commonKeyArtist {
-                artist = try await item.load(.stringValue) ?? "Unknown Artist"
+            if item.commonKey == .commonKeyArtist,
+               let loadedArtist = try await item.load(.stringValue) {
+                artist = loadedArtist
             }
             if item.commonKey == .commonKeyArtwork {
                 albumArt = try await item.load(.dataValue)
             }
         }
         
-        return (title, artist, albumArt)
+        // title이 없거나 "Unknown Title"인 경우 파일 이름(확장자 제외)을 사용
+        if title == nil || title == "Unknown Title" {
+            title = url.deletingPathExtension().lastPathComponent
+        }
+        
+        // artist는 메타데이터가 없을 경우 기본값 유지하거나 다른 처리를 할 수 있음
+        if artist == nil || artist == "Unknown Artist" {
+            artist = "Unknown Artist"
+        }
+        
+        return (title!, artist!, albumArt)
     }
 }
 

--- a/DancingMarker/DancingMarker/View/Main/MusicListView.swift
+++ b/DancingMarker/DancingMarker/View/Main/MusicListView.swift
@@ -136,49 +136,55 @@ struct MusicListView: View {
             }
         }
         .navigationTitle("내 음악")
-        .toolbar {
-            ToolbarItem (placement: .topBarTrailing) {
-                Button(action: {
-                    isFileImporterPresented.toggle()
-                }) {
-                    Text("추가하기")
-                        .foregroundStyle(.accent)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button(action: {
+                        isFileImporterPresented.toggle()
+                    }) {
+                        Text("추가하기")
+                            .foregroundStyle(.accent)
+                    }
                 }
             }
-        }
-        .fileImporter(
-            isPresented: $isFileImporterPresented,
-            allowedContentTypes: [.audio],
-            allowsMultipleSelection: false
-        ) { result in
-            switch result {
-            case .success(let urls):
-                if let url = urls.first {
-                    selectedFileURL = url
-                    isMusicEditViewPresented = true
-                    didSaveMusic = false  // 새로운 파일을 선택할 때마다 초기화
-                }
-            case .failure(let error):
-                print("Failed to import file: \(error.localizedDescription)")
-            }
-        }
-        .sheet(isPresented: $isMusicEditViewPresented, onDismiss: {
-            if !didSaveMusic, selectedMusic == nil {
-                isFileImporterPresented = true  // 저장하지 않고 닫으면 FileImporter 다시 열기
-            }
-            // 초기화
-            selectedMusic = nil
-        }) {
-            NavigationStack {
-                if let selectedMusic = selectedMusic {
-                    // 기존 음원 수정
-                    MusicEditView(music: selectedMusic)
-                } else if let fileURL = selectedFileURL {
-                    // 새 음원 추가
-                    MusicEditView(fileURL: fileURL, didSaveMusic: $didSaveMusic)
+            .fileImporter(
+                isPresented: $isFileImporterPresented,
+                allowedContentTypes: [.audio],
+                allowsMultipleSelection: false
+            ) { result in
+                switch result {
+                case .success(let urls):
+                    if let url = urls.first {
+                        // 파일 선택 후 바로 새 음원을 추가하는 메서드 호출
+                        Task {
+                            await addMusic(from: url)
+                            didSaveMusic = true
+                        }
+                        // MusicEditView를 띄우지 않음
+                        // selectedFileURL = url
+                        // isMusicEditViewPresented = true
+                    }
+                case .failure(let error):
+                    print("Failed to import file: \(error.localizedDescription)")
                 }
             }
-        }
+            .sheet(isPresented: $isMusicEditViewPresented, onDismiss: {
+                if !didSaveMusic, selectedMusic == nil {
+                    isFileImporterPresented = true  // 저장하지 않고 닫으면 FileImporter 다시 열기
+                }
+                // 초기화
+                selectedMusic = nil
+            }) {
+                NavigationStack {
+                    if let selectedMusic = selectedMusic {
+                        // 기존 음원 수정
+                        MusicEditView(music: selectedMusic)
+                    }
+                    // 새 음원 추가용 MusicEditView 부분 제거
+                    // else if let fileURL = selectedFileURL {
+                    //     MusicEditView(fileURL: fileURL, didSaveMusic: $didSaveMusic)
+                    // }
+                }
+            }
         .edgesIgnoringSafeArea(.bottom)
     }
     
@@ -231,6 +237,66 @@ struct MusicListView: View {
             }
             
         }
+    }
+    
+    private func addMusic(from url: URL) async {
+        // 보안 범위 설정 시작
+        guard url.startAccessingSecurityScopedResource() else {
+            print("Failed to start accessing security scoped resource at \(url)")
+            return
+        }
+        
+        defer {
+            // 보안 범위 접근 종료
+            url.stopAccessingSecurityScopedResource()
+        }
+        
+        do {
+            let (title, artist, albumArt) = try await fetchMusicMetadata(from: url)
+            let documentsDirectory = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+            
+            let uniqueFileURL = documentsDirectory.appendingUniquePathComponent(url.lastPathComponent)
+            
+            try FileManager.default.copyItem(at: url, to: uniqueFileURL)
+            
+            let newMusic = Music(
+                title: title,
+                artist: artist,
+                fileName: uniqueFileURL.lastPathComponent,
+                markers: [-1, -1, -1],
+                albumArt: albumArt
+            )
+            
+            modelContext.insert(newMusic)
+            try modelContext.save()
+            
+            playerModel.sendMusicListToWatch(with: musicList)
+        } catch {
+            print("Failed to fetch music metadata: \(error.localizedDescription)")
+        }
+    }
+    
+    private func fetchMusicMetadata(from url: URL) async throws -> (String, String, Data?) {
+        let asset = AVAsset(url: url)
+        let metadata = try await asset.load(.commonMetadata)
+        
+        var title: String = "Unknown Title"
+        var artist: String = "Unknown Artist"
+        var albumArt: Data? = nil
+        
+        for item in metadata {
+            if item.commonKey == .commonKeyTitle {
+                title = try await item.load(.stringValue) ?? "Unknown Title"
+            }
+            if item.commonKey == .commonKeyArtist {
+                artist = try await item.load(.stringValue) ?? "Unknown Artist"
+            }
+            if item.commonKey == .commonKeyArtwork {
+                albumArt = try await item.load(.dataValue)
+            }
+        }
+        
+        return (title, artist, albumArt)
     }
 }
 

--- a/DancingMarker/DancingMarker/View/Main/MusicListView.swift
+++ b/DancingMarker/DancingMarker/View/Main/MusicListView.swift
@@ -13,12 +13,15 @@ import MediaPlayer
 struct MusicListView: View {
     @Environment(NavigationManager.self) var navigationManager
     @Environment(\.modelContext) private var modelContext
+    @EnvironmentObject var playerModel: PlayerModel
+
     @Query var musicList: [Music] = []
+
     @State private var isFileImporterPresented: Bool = false
     @State private var isMusicEditViewPresented: Bool = false
     @State private var selectedFileURL: URL? = nil
     @State private var didSaveMusic: Bool = false
-    @EnvironmentObject var playerModel: PlayerModel
+    @State private var selectedMusic: Music? = nil
     
     var body: some View {
         VStack {
@@ -76,9 +79,9 @@ struct MusicListView: View {
                     //MARK: - 코드 정리 필요
                     .contentShape(Rectangle())
                     .onTapGesture {
-                        let selectedMusic = music
+                        let tappedMusic = music
                         
-                        if playerModel.music == nil || playerModel.music?.id != selectedMusic.id {
+                        if playerModel.music == nil || playerModel.music?.id != tappedMusic.id {
                             // 새로운 곡이 선택되었거나 처음 재생하는 경우
                             playerModel.stopAudio()
                             playerModel.stopTimer()
@@ -86,8 +89,8 @@ struct MusicListView: View {
                             // 오디오 세션 활성화
                             try? AVAudioSession.sharedInstance().setActive(true)
                             
-                            playerModel.music = selectedMusic
-                            playerModel.initAudioPlayer(for: selectedMusic)
+                            playerModel.music = tappedMusic
+                            playerModel.initAudioPlayer(for: tappedMusic)
                             playerModel.isPlaying = true
                             playerModel.playAudio()
                             
@@ -144,33 +147,39 @@ struct MusicListView: View {
             }
         }
         .fileImporter(
-                    isPresented: $isFileImporterPresented,
-                    allowedContentTypes: [.audio],
-                    allowsMultipleSelection: false
-                ) { result in
-                    switch result {
-                    case .success(let urls):
-                        if let url = urls.first {
-                            selectedFileURL = url
-                            isMusicEditViewPresented = true
-                            didSaveMusic = false  // 새로운 파일을 선택할 때마다 초기화
-                        }
-                    case .failure(let error):
-                        print("Failed to import file: \(error.localizedDescription)")
-                    }
+            isPresented: $isFileImporterPresented,
+            allowedContentTypes: [.audio],
+            allowsMultipleSelection: false
+        ) { result in
+            switch result {
+            case .success(let urls):
+                if let url = urls.first {
+                    selectedFileURL = url
+                    isMusicEditViewPresented = true
+                    didSaveMusic = false  // 새로운 파일을 선택할 때마다 초기화
                 }
-                .sheet(isPresented: $isMusicEditViewPresented, onDismiss: {
-                    if !didSaveMusic {
-                        isFileImporterPresented = true  // 저장하지 않고 닫으면 FileImporter 다시 열기
-                    }
-                }) {
-                    if let fileURL = selectedFileURL {
-                        NavigationStack {
-                            MusicEditView(fileURL: fileURL, didSaveMusic: $didSaveMusic)
-                        }
-                    }
+            case .failure(let error):
+                print("Failed to import file: \(error.localizedDescription)")
+            }
+        }
+        .sheet(isPresented: $isMusicEditViewPresented, onDismiss: {
+            if !didSaveMusic, selectedMusic == nil {
+                isFileImporterPresented = true  // 저장하지 않고 닫으면 FileImporter 다시 열기
+            }
+            // 초기화
+            selectedMusic = nil
+        }) {
+            NavigationStack {
+                if let selectedMusic = selectedMusic {
+                    // 기존 음원 수정
+                    MusicEditView(music: selectedMusic)
+                } else if let fileURL = selectedFileURL {
+                    // 새 음원 추가
+                    MusicEditView(fileURL: fileURL, didSaveMusic: $didSaveMusic)
                 }
-                .edgesIgnoringSafeArea(.bottom)
+            }
+        }
+        .edgesIgnoringSafeArea(.bottom)
     }
     
     @ViewBuilder
@@ -184,16 +193,15 @@ struct MusicListView: View {
         playerModel.sendMusicListToWatch(with: musicList)
     }
     
-
-    
     private func musicContextMenu(music: Music) -> some View {
         Group {
-//            Button(action: {
-//                // 수정 기능
-//            }) {
-//                Text("수정하기")
-//                Image(systemName: "pencil")
-//            }
+            Button(action: {
+                selectedMusic = music
+                isMusicEditViewPresented = true
+            }) {
+                Text("수정하기")
+                Image(systemName: "pencil")
+            }
             Button(role: .destructive, action: {
                 DispatchQueue.main.async {
                     if let index = self.musicList.firstIndex(of: music) {
@@ -204,7 +212,7 @@ struct MusicListView: View {
                             playerModel.music = nil       // 음악을 nil로 설정
                             playerModel.updateNowPlayingControlCenter() // Now Playing 정보 업데이트
                         }
-
+                        
                         // 음원 리스트에서 삭제
                         modelContext.delete(musicList[index])
                         do {
@@ -213,7 +221,7 @@ struct MusicListView: View {
                             print("Failed to fetch music metadata: \(error.localizedDescription)")
                         }
                     }
-
+                    
                     // 워치로 업데이트된 음악 리스트 전송
                     playerModel.sendMusicListToWatch(with: musicList)
                 }
@@ -221,7 +229,7 @@ struct MusicListView: View {
                 Text("삭제하기")
                 Image(systemName: "trash")
             }
-
+            
         }
     }
 }

--- a/DancingMarker/DancingMarker/View/Main/MusicListView.swift
+++ b/DancingMarker/DancingMarker/View/Main/MusicListView.swift
@@ -15,6 +15,9 @@ struct MusicListView: View {
     @Environment(\.modelContext) private var modelContext
     @Query var musicList: [Music] = []
     @State private var isFileImporterPresented: Bool = false
+    @State private var isMusicEditViewPresented: Bool = false
+    @State private var selectedFileURL: URL? = nil
+    @State private var didSaveMusic: Bool = false
     @EnvironmentObject var playerModel: PlayerModel
     
     var body: some View {
@@ -52,7 +55,7 @@ struct MusicListView: View {
                                         .resizable()
                                         .padding()
                                         .scaledToFit()
-                                        .foregroundColor(.gray)
+                                        .foregroundStyle(.gray)
                                 }
                         }
                         
@@ -128,7 +131,6 @@ struct MusicListView: View {
                         )
                 }
             }
-            
         }
         .navigationTitle("내 음악")
         .toolbar {
@@ -142,22 +144,33 @@ struct MusicListView: View {
             }
         }
         .fileImporter(
-            isPresented: $isFileImporterPresented,
-            allowedContentTypes: [.audio],
-            allowsMultipleSelection: false
-        ) { result in
-            switch result {
-            case .success(let urls):
-                if let url = urls.first {
-                    Task {
-                        await addMusic(from: url)
+                    isPresented: $isFileImporterPresented,
+                    allowedContentTypes: [.audio],
+                    allowsMultipleSelection: false
+                ) { result in
+                    switch result {
+                    case .success(let urls):
+                        if let url = urls.first {
+                            selectedFileURL = url
+                            isMusicEditViewPresented = true
+                            didSaveMusic = false  // 새로운 파일을 선택할 때마다 초기화
+                        }
+                    case .failure(let error):
+                        print("Failed to import file: \(error.localizedDescription)")
                     }
                 }
-            case .failure(let error):
-                print("Failed to import file: \(error.localizedDescription)")
-            }
-        }
-        .edgesIgnoringSafeArea(.bottom)
+                .sheet(isPresented: $isMusicEditViewPresented, onDismiss: {
+                    if !didSaveMusic {
+                        isFileImporterPresented = true  // 저장하지 않고 닫으면 FileImporter 다시 열기
+                    }
+                }) {
+                    if let fileURL = selectedFileURL {
+                        NavigationStack {
+                            MusicEditView(fileURL: fileURL, didSaveMusic: $didSaveMusic)
+                        }
+                    }
+                }
+                .edgesIgnoringSafeArea(.bottom)
     }
     
     @ViewBuilder
@@ -165,60 +178,13 @@ struct MusicListView: View {
         TipButtonView()
     }
     
-    private func fetchMusicMetadata(from url: URL) async throws -> (String, String, Data?) {
-        let asset = AVAsset(url: url)
-        let metadata = try await asset.load(.commonMetadata)
-        
-        var title: String = "Unknown Title"
-        var artist: String = "Unknown Artist"
-        var albumArt: Data? = nil
-        
-        for item in metadata {
-            if item.commonKey == .commonKeyTitle {
-                title = try await item.load(.stringValue) ?? "Unknown Title"
-            }
-            if item.commonKey == .commonKeyArtist {
-                artist = try await item.load(.stringValue) ?? "Unknown Artist"
-            }
-            if item.commonKey == .commonKeyArtwork {
-                albumArt = try await item.load(.dataValue)
-            }
-        }
-        
-        return (title, artist, albumArt)
+    private func addEditedMusic(_ music: Music) {
+        modelContext.insert(music)
+        try? modelContext.save()
+        playerModel.sendMusicListToWatch(with: musicList)
     }
     
-    private func addMusic(from url: URL) async {
-        // 보안 범위 설정 시작
-        guard url.startAccessingSecurityScopedResource() else {
-            print("Failed to start accessing security scoped resource at \(url)")
-            return
-        }
-        
-        do {
-            let (title, artist, albumArt) = try await fetchMusicMetadata(from: url)
-            let documentsDirectory = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
-            
-            let uniqueFileURL = documentsDirectory.appendingUniquePathComponent(url.lastPathComponent)
-            
-            try FileManager.default.copyItem(at: url, to: uniqueFileURL)
-            
-            let newMusic = Music(
-                title: title,
-                artist: artist,
-                fileName: uniqueFileURL.lastPathComponent,
-                markers: [-1, -1, -1],
-                albumArt: albumArt
-            )
-            
-            modelContext.insert(newMusic)
-            try modelContext.save()
-            
-            playerModel.sendMusicListToWatch(with: musicList)
-        } catch {
-            print("Failed to fetch music metadata: \(error.localizedDescription)")
-        }
-    }
+
     
     private func musicContextMenu(music: Music) -> some View {
         Group {

--- a/DancingMarker/DancingMarker/View/Main/SelectGalleryView.swift
+++ b/DancingMarker/DancingMarker/View/Main/SelectGalleryView.swift
@@ -9,46 +9,46 @@ import SwiftUI
 
 struct SelectGalleryView: UIViewControllerRepresentable {
     @Binding var selectedImgData: Data?
-
-        func makeUIViewController(context: Context) -> UIImagePickerController {
-            let picker = UIImagePickerController()
-            picker.navigationBar.isTranslucent = false
-            picker.sourceType = .photoLibrary
-            picker.delegate = context.coordinator
-            return picker
+    
+    func makeUIViewController(context: Context) -> UIImagePickerController {
+        let picker = UIImagePickerController()
+        picker.navigationBar.isTranslucent = false
+        picker.sourceType = .photoLibrary
+        picker.delegate = context.coordinator
+        return picker
+    }
+    
+    func updateUIViewController(_ uiViewController: UIImagePickerController, context: Context) {}
+    
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+    
+    class Coordinator: NSObject, UINavigationControllerDelegate, UIImagePickerControllerDelegate {
+        var galleryPicker: SelectGalleryView
+        
+        init(_ parent: SelectGalleryView) {
+            self.galleryPicker = parent
         }
-
-        func updateUIViewController(_ uiViewController: UIImagePickerController, context: Context) {}
-
-        func makeCoordinator() -> Coordinator {
-            Coordinator(self)
+        
+        func imagePickerController(
+            _ picker: UIImagePickerController,
+            didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]
+        ) {
+            picker.dismiss(animated: true)
+            
+            // 이미지 선택 시 정방형으로 크롭 후 jpeg 압축
+            guard let image = info[.originalImage] as? UIImage,
+                  let croppedImage = image.croppedToSquare() else {
+                print("이미지 크롭, 압축 실패")
+                return
+            }
+            galleryPicker.selectedImgData = croppedImage.jpegData(compressionQuality: 0.2)
         }
-
-        class Coordinator: NSObject, UINavigationControllerDelegate, UIImagePickerControllerDelegate {
-            var galleryPicker: SelectGalleryView
-
-            init(_ parent: SelectGalleryView) {
-                self.galleryPicker = parent
-            }
-
-            func imagePickerController(
-                _ picker: UIImagePickerController,
-                didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]
-            ) {
-                picker.dismiss(animated: true)
-                
-                // 이미지 선택 시 정방형으로 크롭 후 jpeg 압축
-                guard let image = info[.originalImage] as? UIImage,
-                      let croppedImage = image.croppedToSquare() else {
-                    print("이미지 크롭, 압축 실패")
-                    return
-                }
-                galleryPicker.selectedImgData = croppedImage.jpegData(compressionQuality: 0.2)
-            }
-
-            func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
-                picker.dismiss(animated: true)
-            }
+        
+        func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
+            picker.dismiss(animated: true)
         }
+    }
     
 }

--- a/DancingMarker/DancingMarker/View/Main/SelectGalleryView.swift
+++ b/DancingMarker/DancingMarker/View/Main/SelectGalleryView.swift
@@ -1,0 +1,54 @@
+//
+//  SelectGalleryView.swift
+//  DancingMarker
+//
+//  Created by Woowon Kang on 3/21/25.
+//
+
+import SwiftUI
+
+struct SelectGalleryView: UIViewControllerRepresentable {
+    @Binding var selectedImgData: Data?
+
+        func makeUIViewController(context: Context) -> UIImagePickerController {
+            let picker = UIImagePickerController()
+            picker.navigationBar.isTranslucent = false
+            picker.sourceType = .photoLibrary
+            picker.delegate = context.coordinator
+            return picker
+        }
+
+        func updateUIViewController(_ uiViewController: UIImagePickerController, context: Context) {}
+
+        func makeCoordinator() -> Coordinator {
+            Coordinator(self)
+        }
+
+        class Coordinator: NSObject, UINavigationControllerDelegate, UIImagePickerControllerDelegate {
+            var galleryPicker: SelectGalleryView
+
+            init(_ parent: SelectGalleryView) {
+                self.galleryPicker = parent
+            }
+
+            func imagePickerController(
+                _ picker: UIImagePickerController,
+                didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]
+            ) {
+                picker.dismiss(animated: true)
+                
+                // 이미지 선택 시 정방형으로 크롭 후 jpeg 압축
+                guard let image = info[.originalImage] as? UIImage,
+                      let croppedImage = image.croppedToSquare() else {
+                    print("이미지 크롭, 압축 실패")
+                    return
+                }
+                galleryPicker.selectedImgData = croppedImage.jpegData(compressionQuality: 0.2)
+            }
+
+            func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
+                picker.dismiss(animated: true)
+            }
+        }
+    
+}

--- a/DancingMarker/DancingMarker/View/Playing/PlayingView.swift
+++ b/DancingMarker/DancingMarker/View/Playing/PlayingView.swift
@@ -187,6 +187,7 @@ struct PlayingView: View {
         .navigationBarTitleDisplayMode(.inline)
         .navigationTitle("")
         .navigationBarBackButtonHidden(true)
+        .enableSwipeBack()
         .toolbar {
             ToolbarItem(placement: .navigationBarLeading) {
                 HStack {


### PR DESCRIPTION
- MusicEditView 구현
- PlayingView에서 뒤로가기 스와이프 구현
- 파일 메타데이터 가져오기 로직 수정
  - 기존엔 메타데이터만 인지해서 가져와서 파일명은 가져오지 못했음
  - 파일명을 가져옴 (일반적으로 음원이 아닌경우 파일명만 있는 경우가 많음)
- 저장하기 버튼 영역 수정
---
- MusicManager를 통해 관련함수 통합 필요