### PR TITLE
[Fix] #111 구형 아이폰, 슬라이더 정상화

### DIFF
--- a/DancingMarker/DancingMarker/Extensions/View+.swift
+++ b/DancingMarker/DancingMarker/Extensions/View+.swift
@@ -7,38 +7,55 @@
 
 import SwiftUI
 
-struct SwipeBackModifier: UIViewControllerRepresentable {
+struct EnableSwipeBack: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            .background(EnableSwipeBackRepresentable())
+    }
+}
+
+private struct EnableSwipeBackRepresentable: UIViewControllerRepresentable {
     func makeUIViewController(context: Context) -> UIViewController {
-        let viewController = UIViewController()
+        let controller = UIViewController()
         DispatchQueue.main.async {
-            if let navController = viewController.navigationController {
-                navController.interactivePopGestureRecognizer?.delegate = context.coordinator
-                navController.interactivePopGestureRecognizer?.isEnabled = true
+            if let nav = controller.parentNavigationController {
+                nav.interactivePopGestureRecognizer?.delegate = context.coordinator
+                nav.interactivePopGestureRecognizer?.isEnabled = true
             }
         }
-        return viewController
+        return controller
     }
-    
-    func updateUIViewController(_ uiViewController: UIViewController, context: Context) { }
-    
+
+    func updateUIViewController(_ uiViewController: UIViewController, context: Context) {}
+
     func makeCoordinator() -> Coordinator {
         Coordinator()
     }
-    
+
     class Coordinator: NSObject, UIGestureRecognizerDelegate {
         func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+            // 뒤로가기 제스처가 항상 동작하도록 허용
             return true
         }
-        
-        func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRequireFailureOf otherGestureRecognizer: UIGestureRecognizer) -> Bool {
-            return otherGestureRecognizer is UIPanGestureRecognizer &&
-            !(gestureRecognizer is UIScreenEdgePanGestureRecognizer)
+    }
+}
+
+// UINavigationController를 안전하게 찾는 extension
+private extension UIViewController {
+    var parentNavigationController: UINavigationController? {
+        var parentVC = self.parent
+        while parentVC != nil {
+            if let nav = parentVC as? UINavigationController {
+                return nav
+            }
+            parentVC = parentVC?.parent
         }
+        return nil
     }
 }
 
 extension View {
     func enableSwipeBack() -> some View {
-        self.background(SwipeBackModifier())
+        self.modifier(EnableSwipeBack())
     }
 }

--- a/DancingMarker/DancingMarker/View/Playing/PlayingView.swift
+++ b/DancingMarker/DancingMarker/View/Playing/PlayingView.swift
@@ -108,18 +108,23 @@ struct PlayingView: View {
                             .frame(width: geometry.size.width * CGFloat(playerModel.progress), height: geometry.size.height)
                     }
                     .cornerRadius(12)
-                    .background(Color.red.opacity(0.2))
-                    .gesture(DragGesture(minimumDistance: 0)
-                        .onChanged({ value in
-                            DispatchQueue.main.async {
-                                let newProgress = min(max(0, Double(value.location.x / geometry.size.width)), 1.0)
-                                playerModel.progress = newProgress
-                                let newTime = newProgress * playerModel.duration
-                                playerModel.currentTime = newTime
-                                playerModel.formattedProgress = playerModel.formattedTime(newTime)
-                                playerModel.updateAudioPlayer(with: newTime)
-                            }
-                        }))
+                    .contentShape(
+                        Rectangle()
+                            .inset(by: -6)
+                    )
+                    .highPriorityGesture(
+                        DragGesture(minimumDistance: 0)
+                            .onChanged({ value in
+                                DispatchQueue.main.async {
+                                    let newProgress = min(max(0, Double(value.location.x / geometry.size.width)), 1.0)
+                                    playerModel.progress = newProgress
+                                    let newTime = newProgress * playerModel.duration
+                                    playerModel.currentTime = newTime
+                                    playerModel.formattedProgress = playerModel.formattedTime(newTime)
+                                    playerModel.updateAudioPlayer(with: newTime)
+                                }
+                            })
+                    )
                 }
                 .frame(height: 8)
                 .padding(.bottom, 3)


### PR DESCRIPTION
### 문제 원인 
- SwiftUI에서 슬라이더(DragGesture)와 네비게이션의 뒤로가기(인터랙티브 팝) 제스처가 동일한 터치 이벤트를 두고 경쟁함
- 기존에는 UIKit의 ```GestureRecognizerDelegate```에서 ```shouldRequireFailureOf``` 등을 사용해 뒤로가기 제스처가 슬라이더 드래그보다 우선하도록 강제했음
- 하지만 SwiftUI의 DragGesture도 내부적으로 ```UIPanGestureRecognizer```를 사용하기 때문에,
delegate에서 ```UIPanGestureRecognizer```를 막으면 슬라이더 드래그까지 막히는 부작용이 발생
- 기기/OS 버전에 따라 동작이 달라져, 어떤 기기에서는 슬라이더가 아예 동작하지 않거나, 어떤 기기에서는 뒤로가기 제스처가 슬라이더 위에서 동작하지 않는 문제가 발생함

### 변경 내용
1. 슬라이더 터치 영역 확장
- 슬라이더 바 위 아래로 터치 영역을 확장하여 손으로 드래그시 실수 적어지도록 유도  
``` .contentShape(Rectangle().inset(by: -6)) ```

2. 제스처 우선순위 명확하게 지정
```.highPriorityGesture(DragGesture(...)) ``` 적용  
→ 슬라이더 영역에서는 DragGesture가 우선적으로 인식
→ 슬라이더 바 바깥에서는 뒤로가기(인터랙티브 팝) 제스처가 정상 동작

``` swift
GeometryReader { geometry in
    ZStack(alignment: .leading) {
        Rectangle()
            .foregroundStyle(.inactiveGray)
        Rectangle()
            .foregroundStyle(.white)
            .frame(width: geometry.size.width * CGFloat(playerModel.progress), height: geometry.size.height)
    }
    .cornerRadius(12)
    .contentShape(
        Rectangle()
            .inset(by: -6) // 터치 영역만 확장
    )
    .highPriorityGesture(
        DragGesture(minimumDistance: 0)
            .onChanged { value in
                let newProgress = min(max(0, Double(value.location.x / geometry.size.width)), 1.0)
                playerModel.progress = newProgress
                let newTime = newProgress * playerModel.duration
                playerModel.currentTime = newTime
                playerModel.formattedProgress = playerModel.formattedTime(newTime)
                playerModel.updateAudioPlayer(with: newTime)
            }
    )
}
.frame(height: 8)

```

3. View+
- 복잡했던 delegate 우선순위 조정 코드 제거

---
아이폰12, 아이폰15프로 실기기 테스트 완료...
