### PR TITLE
[Fix] #130 워치 동기화 로직 개선

### DIFF
--- a/DancingMarker/DancingMarker/Services/WatchService.swift
+++ b/DancingMarker/DancingMarker/Services/WatchService.swift
@@ -370,29 +370,32 @@ final class WatchService: NSObject, ObservableObject, WatchConnectivityManageabl
     // MARK: - Private Helper Methods
     
     private func sendMessage(_ message: [String: Any]) async throws {
-        print("🎯 WatchService: 메시지 전송 시도")
-        print("   - 메시지 액션: \(message["action"] ?? "Unknown")")
+        print("�� WatchService: 메시지 전송 시도")
         
-        // WCManager의 세션 상태 확인
         let wcManagerSession = WCSession.default
-        print("   - WCSession.default.isReachable: \(wcManagerSession.isReachable)")
-        print("   - WCSession.default.activationState: \(wcManagerSession.activationState.rawValue)")
-        
         guard wcManagerSession.isReachable else {
-            print("🚨 WatchService: 워치에 연결할 수 없음 (isReachable: false)")
             throw DancingMarkerError.watchNotConnected
         }
         
         return try await withCheckedThrowingContinuation { continuation in
+            var hasResumed = false  // 🛡️ 간단한 플래그
+            
             wcManagerSession.sendMessage(message) { replyHandler in
-                print("✅ WatchService: 메시지 전송 성공, 응답: \(replyHandler)")
-                continuation.resume()
-            } errorHandler: { error in
-                print("🚨 WatchService: 메시지 전송 실패")
-                print("   - 원본 에러: \(error.localizedDescription)")
-                print("   - 에러 코드: \(error._code)")
-                print("   - 에러 도메인: \(error._domain)")
+                guard !hasResumed else { 
+                    print("⚠️ 이미 처리됨 - 무시")
+                    return 
+                }
+                hasResumed = true
+                print("✅ WatchService: 메시지 전송 성공")
+                continuation.resume(returning: ())
                 
+            } errorHandler: { error in
+                guard !hasResumed else { 
+                    print("⚠️ 이미 처리됨 - 무시") 
+                    return 
+                }
+                hasResumed = true
+                print("🚨 WatchService: 메시지 전송 실패: \(error)")
                 continuation.resume(throwing: DancingMarkerError.watchSendFailed)
             }
         }

--- a/DancingMarker/WatchDancingMarker Watch App/ViewModel/WatchViewModel.swift
+++ b/DancingMarker/WatchDancingMarker Watch App/ViewModel/WatchViewModel.swift
@@ -27,7 +27,7 @@ class WatchViewModel: ObservableObject {
     @Published var lastSentCrownValue: Float = 0.5  // 마지막으로 전송된 Crown 값
 
     @Published private var isMarkerSeeking: Bool = false
-    @Published var hasSelectedMusic: Bool = false  // ★ 추가
+    @Published var hasSelectedMusic: Bool = false
     
     private var timer: Timer?
     
@@ -101,7 +101,6 @@ class WatchViewModel: ObservableObject {
     }
     
     @objc func updateIsPlaying(_ notification: Notification) {
-        
         if let isPlaying = notification.object as? Bool {
             DispatchQueue.main.async {
                 self.isPlaying = isPlaying
@@ -125,6 +124,11 @@ class WatchViewModel: ObservableObject {
                 self.duration = playingTimes[1]
                 self.progress = self.currentTime / self.duration
                 self.formattedProgress = self.formattedTime(self.currentTime)
+                
+                // duration > 0이면 음원이 로드된 상태
+                if self.duration > 0 {
+                    self.hasSelectedMusic = true
+                }
             }
         }
     }
@@ -135,13 +139,13 @@ class WatchViewModel: ObservableObject {
             UserDefaults.standard.clearMusicList()
             UserDefaults.standard.saveMusicList(musics)
             self.musicList = musics
+            self.hasSelectedMusic = false
         }
     }
     
     @objc func updateMusicTitle(_ notification: Notification) {
         if let musicTitle = notification.object as? String {
             self.musicTitle = musicTitle
-            self.hasSelectedMusic = !musicTitle.isEmpty  // ★ 추가
         }
     }
     
@@ -181,6 +185,7 @@ class WatchViewModel: ObservableObject {
     
     func sendUUID(id: String) {
         connectivityManager.sendUUIDPlayToIOS(id)
+        self.hasSelectedMusic = true
     }
     
     func deletemarker(index: Int){

--- a/DancingMarker/WatchDancingMarker Watch App/ViewModel/WatchViewModel.swift
+++ b/DancingMarker/WatchDancingMarker Watch App/ViewModel/WatchViewModel.swift
@@ -224,6 +224,12 @@ class WatchViewModel: ObservableObject {
     
     private func updateTime() {
         guard isPlaying else { return }
+        
+        guard connectivityManager.isReachable else { 
+            stopTimer()
+            return 
+        }
+        
         currentTime += 1
         if currentTime >= duration {
             currentTime = 0


### PR DESCRIPTION
## 작업 내용
- 워치 동기화 로직 개선
- WatchListView 툴바 애니메이션 로직 개선
---

### **WatchViewModel.swift**
```swift
// updateTime()에 연결 상태 체크 추가
guard connectivityManager.isReachable else { 
    stopTimer()
    return 
}

// hasSelectedMusic 로직을 updatePlayingTimes로 이동
if self.duration > 0 {
    self.hasSelectedMusic = true
}
```
- 워치 연결이 끊겼을때, 타이머를 멈춰 프로그레스바가 계속 돌아가는 문제를 해결합니다.
- WatchMusicListView에서 노래 재생 상태를 명확히 확인 후 툴바가 표시되게 합니다.

###  **WatchService CheckedContinuation 크래시 문제**
**증상**: iPhone 16 + iOS 18.5 환경에서 앱이 예기치 않게 종료됨
**에러**: `CheckedContinuation.resume(throwing:) tried to resume more than once`
**발생 위치**: `WatchService.sendMessage(_:)` 메서드

```swift
// 기존 코드 (크래시 발생 가능)
return try await withCheckedThrowingContinuation { continuation in
    wcManagerSession.sendMessage(message) { replyHandler in
        continuation.resume(returning: ())  // ✅ 성공 시
    } errorHandler: { error in
        continuation.resume(throwing: error)  // ❌ 실패 시 → 중복 resume으로 크래시!
    }
}
```

### 해결 코드 부분
```swift
// hasResumed 플래그로 중복 처리 방지
var hasResumed = false
guard !hasResumed else { return }
hasResumed = true
```

1. **`hasResumed` 플래그**: 이미 처리된 요청인지 확인
2. **Early Return**: 중복 호출 시 즉시 무시하고 종료