### PR TITLE
[Refactor] #139 Watch 앱 아키텍처 개선 - ViewModel 분리 및 서비스 기반 구조 도입

### DIFF
--- a/DancingMarker/DancingMarker.xcodeproj/project.pbxproj
+++ b/DancingMarker/DancingMarker.xcodeproj/project.pbxproj
@@ -35,6 +35,12 @@
 		510FA43B2E43AB3A00287EAD /* WatchViewModel+Data.swift in Sources */ = {isa = PBXBuildFile; fileRef = 510FA43A2E43AB3A00287EAD /* WatchViewModel+Data.swift */; };
 		510FA43D2E43AB8E00287EAD /* WatchViewModel+Sync.swift in Sources */ = {isa = PBXBuildFile; fileRef = 510FA43C2E43AB8E00287EAD /* WatchViewModel+Sync.swift */; };
 		510FA43F2E43ABB100287EAD /* WatchViewModel+Timer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 510FA43E2E43ABB100287EAD /* WatchViewModel+Timer.swift */; };
+		510FA4412E43B52B00287EAD /* WatchSyncable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 510FA4402E43B52B00287EAD /* WatchSyncable.swift */; };
+		510FA4432E43B54200287EAD /* WatchSyncService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 510FA4422E43B54200287EAD /* WatchSyncService.swift */; };
+		510FA4452E43B55500287EAD /* WatchDataManageable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 510FA4442E43B55500287EAD /* WatchDataManageable.swift */; };
+		510FA4472E43B56500287EAD /* WatchDataService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 510FA4462E43B56500287EAD /* WatchDataService.swift */; };
+		510FA4492E43B57900287EAD /* WatchTimerable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 510FA4482E43B57900287EAD /* WatchTimerable.swift */; };
+		510FA44B2E43B59400287EAD /* WatchTimerService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 510FA44A2E43B59400287EAD /* WatchTimerService.swift */; };
 		512224C02D8C685E00AABC82 /* UIImage+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 512224BF2D8C685500AABC82 /* UIImage+.swift */; };
 		512224C22D8C68D100AABC82 /* SelectGalleryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 512224C12D8C68C900AABC82 /* SelectGalleryView.swift */; };
 		512CED492DF08E59001A800B /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 512CED482DF08E59001A800B /* Errors.swift */; };
@@ -151,6 +157,12 @@
 		510FA43A2E43AB3A00287EAD /* WatchViewModel+Data.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WatchViewModel+Data.swift"; sourceTree = "<group>"; };
 		510FA43C2E43AB8E00287EAD /* WatchViewModel+Sync.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WatchViewModel+Sync.swift"; sourceTree = "<group>"; };
 		510FA43E2E43ABB100287EAD /* WatchViewModel+Timer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WatchViewModel+Timer.swift"; sourceTree = "<group>"; };
+		510FA4402E43B52B00287EAD /* WatchSyncable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchSyncable.swift; sourceTree = "<group>"; };
+		510FA4422E43B54200287EAD /* WatchSyncService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchSyncService.swift; sourceTree = "<group>"; };
+		510FA4442E43B55500287EAD /* WatchDataManageable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchDataManageable.swift; sourceTree = "<group>"; };
+		510FA4462E43B56500287EAD /* WatchDataService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchDataService.swift; sourceTree = "<group>"; };
+		510FA4482E43B57900287EAD /* WatchTimerable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchTimerable.swift; sourceTree = "<group>"; };
+		510FA44A2E43B59400287EAD /* WatchTimerService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchTimerService.swift; sourceTree = "<group>"; };
 		512224BF2D8C685500AABC82 /* UIImage+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+.swift"; sourceTree = "<group>"; };
 		512224C12D8C68C900AABC82 /* SelectGalleryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectGalleryView.swift; sourceTree = "<group>"; };
 		512CED482DF08E59001A800B /* Errors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Errors.swift; sourceTree = "<group>"; };
@@ -387,6 +399,9 @@
 			isa = PBXGroup;
 			children = (
 				5149F3A52E43A40E00482C2A /* WatchCommunicationService.swift */,
+				510FA4422E43B54200287EAD /* WatchSyncService.swift */,
+				510FA4462E43B56500287EAD /* WatchDataService.swift */,
+				510FA44A2E43B59400287EAD /* WatchTimerService.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -395,6 +410,9 @@
 			isa = PBXGroup;
 			children = (
 				5149F3A32E43A3EE00482C2A /* WatchCommunicatable.swift */,
+				510FA4402E43B52B00287EAD /* WatchSyncable.swift */,
+				510FA4442E43B55500287EAD /* WatchDataManageable.swift */,
+				510FA4482E43B57900287EAD /* WatchTimerable.swift */,
 			);
 			path = Protocols;
 			sourceTree = "<group>";
@@ -839,7 +857,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				510FA4412E43B52B00287EAD /* WatchSyncable.swift in Sources */,
 				510FA43B2E43AB3A00287EAD /* WatchViewModel+Data.swift in Sources */,
+				510FA4492E43B57900287EAD /* WatchTimerable.swift in Sources */,
 				512CEE682DF12E06001A800B /* MusicData.swift in Sources */,
 				90A472322C450AB6008577A2 /* WCManager.swift in Sources */,
 				902077062C458ABB00988D2B /* WatchViewModel.swift in Sources */,
@@ -850,13 +870,17 @@
 				510D90262CA2F1C0002E82CC /* WatchMusicListView.swift in Sources */,
 				51C107242E41ED6900999C0B /* WatchMusicInfoHeader.swift in Sources */,
 				510FA43D2E43AB8E00287EAD /* WatchViewModel+Sync.swift in Sources */,
+				510FA4452E43B55500287EAD /* WatchDataManageable.swift in Sources */,
 				51447EF62E41E70900ED1669 /* WatchMusicGrid.swift in Sources */,
 				51447EF42E41E6EF00ED1669 /* WatchEmptyMusicView.swift in Sources */,
 				512CED492DF08E59001A800B /* Errors.swift in Sources */,
 				510FA4392E43AB2200287EAD /* WatchViewModel+Communication.swift in Sources */,
 				510D901A2CA2F1C0002E82CC /* WatchMarkerDetailView.swift in Sources */,
 				510D901B2CA2F1C0002E82CC /* WatchMarkerEditView.swift in Sources */,
+				510FA4472E43B56500287EAD /* WatchDataService.swift in Sources */,
+				510FA4432E43B54200287EAD /* WatchSyncService.swift in Sources */,
 				510D901C2CA2F1C0002E82CC /* WatchMarkerListView.swift in Sources */,
+				510FA44B2E43B59400287EAD /* WatchTimerService.swift in Sources */,
 				5104B7F82C3D6C3F008E10E8 /* Music.swift in Sources */,
 				51447EF82E41E74100ED1669 /* WatchPlayingIndicator.swift in Sources */,
 				90A472312C450A68008577A2 /* WatchDancingMarkerApp.swift in Sources */,

--- a/DancingMarker/DancingMarker.xcodeproj/project.pbxproj
+++ b/DancingMarker/DancingMarker.xcodeproj/project.pbxproj
@@ -31,6 +31,10 @@
 		510D90312CA2F1C8002E82CC /* PlayingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 510D902E2CA2F1C8002E82CC /* PlayingView.swift */; };
 		510D90322CA2F1C8002E82CC /* TipPopupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 510D902F2CA2F1C8002E82CC /* TipPopupView.swift */; };
 		510D90352CA2F1C8002E82CC /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 510D90332CA2F1C8002E82CC /* ContentView.swift */; };
+		510FA4392E43AB2200287EAD /* WatchViewModel+Communication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 510FA4382E43AB2200287EAD /* WatchViewModel+Communication.swift */; };
+		510FA43B2E43AB3A00287EAD /* WatchViewModel+Data.swift in Sources */ = {isa = PBXBuildFile; fileRef = 510FA43A2E43AB3A00287EAD /* WatchViewModel+Data.swift */; };
+		510FA43D2E43AB8E00287EAD /* WatchViewModel+Sync.swift in Sources */ = {isa = PBXBuildFile; fileRef = 510FA43C2E43AB8E00287EAD /* WatchViewModel+Sync.swift */; };
+		510FA43F2E43ABB100287EAD /* WatchViewModel+Timer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 510FA43E2E43ABB100287EAD /* WatchViewModel+Timer.swift */; };
 		512224C02D8C685E00AABC82 /* UIImage+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 512224BF2D8C685500AABC82 /* UIImage+.swift */; };
 		512224C22D8C68D100AABC82 /* SelectGalleryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 512224C12D8C68C900AABC82 /* SelectGalleryView.swift */; };
 		512CED492DF08E59001A800B /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 512CED482DF08E59001A800B /* Errors.swift */; };
@@ -143,6 +147,10 @@
 		510D902E2CA2F1C8002E82CC /* PlayingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayingView.swift; sourceTree = "<group>"; };
 		510D902F2CA2F1C8002E82CC /* TipPopupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TipPopupView.swift; sourceTree = "<group>"; };
 		510D90332CA2F1C8002E82CC /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		510FA4382E43AB2200287EAD /* WatchViewModel+Communication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WatchViewModel+Communication.swift"; sourceTree = "<group>"; };
+		510FA43A2E43AB3A00287EAD /* WatchViewModel+Data.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WatchViewModel+Data.swift"; sourceTree = "<group>"; };
+		510FA43C2E43AB8E00287EAD /* WatchViewModel+Sync.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WatchViewModel+Sync.swift"; sourceTree = "<group>"; };
+		510FA43E2E43ABB100287EAD /* WatchViewModel+Timer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WatchViewModel+Timer.swift"; sourceTree = "<group>"; };
 		512224BF2D8C685500AABC82 /* UIImage+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+.swift"; sourceTree = "<group>"; };
 		512224C12D8C68C900AABC82 /* SelectGalleryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectGalleryView.swift; sourceTree = "<group>"; };
 		512CED482DF08E59001A800B /* Errors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Errors.swift; sourceTree = "<group>"; };
@@ -473,6 +481,10 @@
 			isa = PBXGroup;
 			children = (
 				902077052C458ABB00988D2B /* WatchViewModel.swift */,
+				510FA4382E43AB2200287EAD /* WatchViewModel+Communication.swift */,
+				510FA43A2E43AB3A00287EAD /* WatchViewModel+Data.swift */,
+				510FA43C2E43AB8E00287EAD /* WatchViewModel+Sync.swift */,
+				510FA43E2E43ABB100287EAD /* WatchViewModel+Timer.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -827,17 +839,21 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				510FA43B2E43AB3A00287EAD /* WatchViewModel+Data.swift in Sources */,
 				512CEE682DF12E06001A800B /* MusicData.swift in Sources */,
 				90A472322C450AB6008577A2 /* WCManager.swift in Sources */,
 				902077062C458ABB00988D2B /* WatchViewModel.swift in Sources */,
+				510FA43F2E43ABB100287EAD /* WatchViewModel+Timer.swift in Sources */,
 				51C107262E41ED9700999C0B /* WatchMusicTimeDisplay.swift in Sources */,
 				5149F3A62E43A40E00482C2A /* WatchCommunicationService.swift in Sources */,
 				1FA811892D534029004B4807 /* MarkerResetAlert.swift in Sources */,
 				510D90262CA2F1C0002E82CC /* WatchMusicListView.swift in Sources */,
 				51C107242E41ED6900999C0B /* WatchMusicInfoHeader.swift in Sources */,
+				510FA43D2E43AB8E00287EAD /* WatchViewModel+Sync.swift in Sources */,
 				51447EF62E41E70900ED1669 /* WatchMusicGrid.swift in Sources */,
 				51447EF42E41E6EF00ED1669 /* WatchEmptyMusicView.swift in Sources */,
 				512CED492DF08E59001A800B /* Errors.swift in Sources */,
+				510FA4392E43AB2200287EAD /* WatchViewModel+Communication.swift in Sources */,
 				510D901A2CA2F1C0002E82CC /* WatchMarkerDetailView.swift in Sources */,
 				510D901B2CA2F1C0002E82CC /* WatchMarkerEditView.swift in Sources */,
 				510D901C2CA2F1C0002E82CC /* WatchMarkerListView.swift in Sources */,

--- a/DancingMarker/DancingMarker.xcodeproj/project.pbxproj
+++ b/DancingMarker/DancingMarker.xcodeproj/project.pbxproj
@@ -54,6 +54,8 @@
 		51447EF42E41E6EF00ED1669 /* WatchEmptyMusicView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51447EF32E41E6EF00ED1669 /* WatchEmptyMusicView.swift */; };
 		51447EF62E41E70900ED1669 /* WatchMusicGrid.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51447EF52E41E70900ED1669 /* WatchMusicGrid.swift */; };
 		51447EF82E41E74100ED1669 /* WatchPlayingIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51447EF72E41E74100ED1669 /* WatchPlayingIndicator.swift */; };
+		5149F3A42E43A3EE00482C2A /* WatchCommunicatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5149F3A32E43A3EE00482C2A /* WatchCommunicatable.swift */; };
+		5149F3A62E43A40E00482C2A /* WatchCommunicationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5149F3A52E43A40E00482C2A /* WatchCommunicationService.swift */; };
 		514F1E2A2E3C9C2100690DB5 /* MusicInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 514F1E292E3C9C2100690DB5 /* MusicInfoView.swift */; };
 		514F1E2C2E3C9DD100690DB5 /* SpeedControlView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 514F1E2B2E3C9DD100690DB5 /* SpeedControlView.swift */; };
 		514F1E2E2E3C9E0400690DB5 /* PlaybackControlsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 514F1E2D2E3C9E0400690DB5 /* PlaybackControlsView.swift */; };
@@ -161,6 +163,8 @@
 		51447EF32E41E6EF00ED1669 /* WatchEmptyMusicView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchEmptyMusicView.swift; sourceTree = "<group>"; };
 		51447EF52E41E70900ED1669 /* WatchMusicGrid.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchMusicGrid.swift; sourceTree = "<group>"; };
 		51447EF72E41E74100ED1669 /* WatchPlayingIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchPlayingIndicator.swift; sourceTree = "<group>"; };
+		5149F3A32E43A3EE00482C2A /* WatchCommunicatable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchCommunicatable.swift; sourceTree = "<group>"; };
+		5149F3A52E43A40E00482C2A /* WatchCommunicationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchCommunicationService.swift; sourceTree = "<group>"; };
 		514F1E292E3C9C2100690DB5 /* MusicInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicInfoView.swift; sourceTree = "<group>"; };
 		514F1E2B2E3C9DD100690DB5 /* SpeedControlView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeedControlView.swift; sourceTree = "<group>"; };
 		514F1E2D2E3C9E0400690DB5 /* PlaybackControlsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaybackControlsView.swift; sourceTree = "<group>"; };
@@ -369,6 +373,22 @@
 				51447EF72E41E74100ED1669 /* WatchPlayingIndicator.swift */,
 			);
 			path = Components;
+			sourceTree = "<group>";
+		};
+		5149F3A12E43A1A100482C2A /* Services */ = {
+			isa = PBXGroup;
+			children = (
+				5149F3A52E43A40E00482C2A /* WatchCommunicationService.swift */,
+			);
+			path = Services;
+			sourceTree = "<group>";
+		};
+		5149F3A22E43A1C800482C2A /* Protocols */ = {
+			isa = PBXGroup;
+			children = (
+				5149F3A32E43A3EE00482C2A /* WatchCommunicatable.swift */,
+			);
+			path = Protocols;
 			sourceTree = "<group>";
 		};
 		514F1E282E3C9C0600690DB5 /* Components */ = {
@@ -586,6 +606,8 @@
 		901BF9932C29809900C02FF9 /* WatchDancingMarker Watch App */ = {
 			isa = PBXGroup;
 			children = (
+				5149F3A22E43A1C800482C2A /* Protocols */,
+				5149F3A12E43A1A100482C2A /* Services */,
 				510D90152CA2F1A7002E82CC /* Application */,
 				1FA811842D53398B004B4807 /* Common */,
 				518D7F012CA2E1D700612544 /* ViewModel */,
@@ -809,6 +831,7 @@
 				90A472322C450AB6008577A2 /* WCManager.swift in Sources */,
 				902077062C458ABB00988D2B /* WatchViewModel.swift in Sources */,
 				51C107262E41ED9700999C0B /* WatchMusicTimeDisplay.swift in Sources */,
+				5149F3A62E43A40E00482C2A /* WatchCommunicationService.swift in Sources */,
 				1FA811892D534029004B4807 /* MarkerResetAlert.swift in Sources */,
 				510D90262CA2F1C0002E82CC /* WatchMusicListView.swift in Sources */,
 				51C107242E41ED6900999C0B /* WatchMusicInfoHeader.swift in Sources */,
@@ -821,6 +844,7 @@
 				5104B7F82C3D6C3F008E10E8 /* Music.swift in Sources */,
 				51447EF82E41E74100ED1669 /* WatchPlayingIndicator.swift in Sources */,
 				90A472312C450A68008577A2 /* WatchDancingMarkerApp.swift in Sources */,
+				5149F3A42E43A3EE00482C2A /* WatchCommunicatable.swift in Sources */,
 				517F19982E425A15000B721E /* MarkerSaveButton.swift in Sources */,
 				517F19962E4259DA000B721E /* MarkerTimeControl.swift in Sources */,
 				901BF9B62C2A533200C02FF9 /* WatchNavigationManager.swift in Sources */,

--- a/DancingMarker/DancingMarker.xcodeproj/xcuserdata/woowonkang.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/DancingMarker/DancingMarker.xcodeproj/xcuserdata/woowonkang.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -7,7 +7,7 @@
 		<key>DancingMarker.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>1</integer>
+			<integer>0</integer>
 		</dict>
 		<key>WatchDancingMarker Watch App (Notification).xcscheme_^#shared#^_</key>
 		<dict>
@@ -17,7 +17,7 @@
 		<key>WatchDancingMarker Watch App.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>0</integer>
+			<integer>1</integer>
 		</dict>
 	</dict>
 </dict>

--- a/DancingMarker/Manager/WCManager.swift
+++ b/DancingMarker/Manager/WCManager.swift
@@ -106,7 +106,6 @@ class WatchConnectivityManager: NSObject, ObservableObject, WCSessionDelegate {
         print("   - session.isReachable: \(session.isReachable)")
         print("   - session.activationState: \(session.activationState.rawValue)")
         
-        // ✅ 직접 처리하도록 변경
         switch action {
         case "SendRequireMusicList":
             print(" WCManager: 음악 목록 요청 수신")
@@ -550,7 +549,6 @@ class WatchConnectivityManager: NSObject, ObservableObject, WCSessionDelegate {
         }
     }
 
-    // ✅ triggerAutoSync 메서드 추가
     private func triggerAutoSync() {
         print("🎯 triggerAutoSync 호출됨")
         

--- a/DancingMarker/WatchDancingMarker Watch App/Protocols/WatchCommunicatable.swift
+++ b/DancingMarker/WatchDancingMarker Watch App/Protocols/WatchCommunicatable.swift
@@ -1,0 +1,69 @@
+//
+//  WatchCommunicatable.swift
+//  WatchDancingMarker Watch App
+//
+//  Created by Woowon Kang on 8/6/25.
+//
+
+import Foundation
+
+/// 워치와 iOS 간 통신을 담당하는 프로토콜
+protocol WatchCommunicatable {
+    
+    // MARK: - Connection Status
+    
+    /// 현재 연결 상태
+    var isReachable: Bool { get }
+    
+    // MARK: - Playback Control
+    
+    /// 재생/일시정지 토글
+    func sendPlayToggle()
+    
+    /// 5초 앞으로 이동
+    func sendForward()
+    
+    /// 5초 뒤로 이동
+    func sendBackward()
+    
+    /// 재생 속도 증가
+    func sendIncreasePlayback()
+    
+    /// 재생 속도 감소
+    func sendDecreasePlayback()
+    
+    /// 재생 속도 원래대로
+    func sendOriginalPlayback()
+    
+    // MARK: - Music Selection
+    
+    /// UUID로 음악 선택
+    func sendMusicSelection(_ musicID: String)
+    
+    // MARK: - Marker Control
+    
+    /// 마커 재생
+    func sendMarkerPlay(at index: Int)
+    
+    /// 마커 저장
+    func sendMarkerSave(at index: Int)
+    
+    /// 마커 삭제
+    func sendMarkerDelete(at index: Int)
+    
+    /// 마커 편집 완료
+    func sendMarkerEditSuccess(index: Int, time: Int)
+    
+    // MARK: - Volume Control
+    
+    /// 볼륨 변경
+    func sendVolumeChange(_ volume: Float)
+    
+    // MARK: - Sync Requests
+    
+    /// 음악 목록 요청
+    func requestMusicList()
+    
+    /// 현재 상태 즉시 동기화 요청
+    func requestCurrentState()
+}

--- a/DancingMarker/WatchDancingMarker Watch App/Protocols/WatchDataManageable.swift
+++ b/DancingMarker/WatchDancingMarker Watch App/Protocols/WatchDataManageable.swift
@@ -1,0 +1,34 @@
+//
+//  WatchDataManageable.swift
+//  WatchDancingMarker Watch App
+//
+//  Created by Woowon Kang on 8/7/25.
+//
+
+import Foundation
+
+/// 워치 데이터 관리를 담당하는 프로토콜
+protocol WatchDataManageable {
+    
+    // MARK: - UserDefaults Management
+    
+    /// 음악 목록을 저장합니다
+    func saveMusicList(_ list: [[String]])
+    
+    /// 음악 목록을 가져옵니다
+    func getMusicList() -> [[String]]
+    
+    /// 음악 목록을 삭제합니다
+    func clearMusicList()
+    
+    // MARK: - Data Processing
+    
+    /// TimeInterval을 포맷팅된 문자열로 변환합니다
+    func formattedTime(_ time: TimeInterval) -> String
+    
+    /// 마커 데이터를 처리합니다
+    func processMarkers(_ markers: [TimeInterval]) -> [String]
+    
+    /// 재생 시간 데이터를 처리합니다
+    func processPlayingTimes(_ playingTimes: [TimeInterval]) -> (currentTime: TimeInterval, duration: TimeInterval, progress: Double, formattedProgress: String)
+}

--- a/DancingMarker/WatchDancingMarker Watch App/Protocols/WatchSyncable.swift
+++ b/DancingMarker/WatchDancingMarker Watch App/Protocols/WatchSyncable.swift
@@ -1,0 +1,42 @@
+//
+//  WatchSyncable.swift
+//  WatchDancingMarker Watch App
+//
+//  Created by Woowon Kang on 8/7/25.
+//
+
+import Foundation
+
+/// 워치 동기화를 담당하는 프로토콜
+protocol WatchSyncable {
+    
+    // MARK: - ApplicationContext
+    
+    /// ApplicationContext에서 음악 목록을 가져옵니다
+    func getMusicListFromApplicationContext() -> [[String]]?
+    
+    /// ApplicationContext가 유효한지 확인합니다
+    func isApplicationContextValid() -> Bool
+    
+    /// ApplicationContext에서 마지막 업데이트 시간을 가져옵니다
+    func getLastUpdateTimeFromApplicationContext() -> TimeInterval?
+    
+    // MARK: - Sync Operations
+    
+    /// 통합 동기화 (ApplicationContext + 실시간 요청)
+    func syncMusicList() async
+    
+    /// 연결 대기 후 실시간 동기화 요청
+    func waitForConnectionAndRequestSync() async
+    
+    /// 앱 활성화 시 동기화
+    func syncOnAppBecomesActive() async
+    
+    /// 강제 전체 동기화
+    func forceFullSync() async
+    
+    // MARK: - Connection Status
+    
+    /// 현재 연결 상태
+    var isReachable: Bool { get }
+}

--- a/DancingMarker/WatchDancingMarker Watch App/Protocols/WatchTimerable.swift
+++ b/DancingMarker/WatchDancingMarker Watch App/Protocols/WatchTimerable.swift
@@ -1,0 +1,42 @@
+//
+//  WatchTimerable.swift
+//  WatchDancingMarker Watch App
+//
+//  Created by Woowon Kang on 8/7/25.
+//
+
+import Foundation
+
+/// 워치 타이머 관리를 담당하는 프로토콜
+protocol WatchTimerable {
+    
+    // MARK: - Timer Control
+    
+    /// 타이머를 시작합니다
+    func startTimer()
+    
+    /// 타이머를 중지합니다
+    func stopTimer()
+    
+    /// 타이머 상태를 확인합니다
+    var isTimerRunning: Bool { get }
+    
+    // MARK: - Timer State Management
+    
+    /// 타이머 강제 재시작
+    func restartTimerIfNeeded(isPlaying: Bool)
+    
+    /// 타이머 상태를 재생 상태와 동기화
+    func syncTimerWithPlayingState(isPlaying: Bool)
+    
+    // MARK: - Seeking Protection
+    
+    /// 마커 연타 방지를 위한 보호 메서드
+    func withSeekingProtection<T>(_ operation: () async throws -> T) async rethrows -> T?
+}
+
+/// 타이머 이벤트를 받는 델리게이트
+protocol WatchTimerDelegate: AnyObject {
+    func timerDidUpdateTime()
+    func timerDidComplete()
+}

--- a/DancingMarker/WatchDancingMarker Watch App/Protocols/WatchTimerable.swift
+++ b/DancingMarker/WatchDancingMarker Watch App/Protocols/WatchTimerable.swift
@@ -10,6 +10,9 @@ import Foundation
 /// 워치 타이머 관리를 담당하는 프로토콜
 protocol WatchTimerable {
     
+    // MARK: - Delegate
+    var delegate: WatchTimerDelegate? { get set }
+    
     // MARK: - Timer Control
     
     /// 타이머를 시작합니다

--- a/DancingMarker/WatchDancingMarker Watch App/Services/WatchCommunicationService.swift
+++ b/DancingMarker/WatchDancingMarker Watch App/Services/WatchCommunicationService.swift
@@ -1,0 +1,108 @@
+//
+//  WatchCommunicationService.swift
+//  WatchDancingMarker Watch App
+//
+//  Created by Woowon Kang on 8/6/25.
+//
+
+import Foundation
+
+/// WatchConnectivityManager를 래핑하여 순수 통신 기능만 제공하는 서비스
+final class WatchCommunicationService: WatchCommunicatable {
+    
+    // MARK: - Properties
+    
+    private let connectivityManager: WatchConnectivityManager
+    
+    // MARK: - Initialization
+    
+    init(connectivityManager: WatchConnectivityManager = WatchConnectivityManager()) {
+        self.connectivityManager = connectivityManager
+    }
+    
+    // MARK: - Connection Status
+    
+    var isReachable: Bool {
+        connectivityManager.isReachable
+    }
+    
+    // MARK: - Playback Control
+    
+    func sendPlayToggle() {
+        connectivityManager.sendPlayToggleToIOS()
+        print("🎮 WatchCommunicationService: 재생/일시정지 토글 전송")
+    }
+    
+    func sendForward() {
+        connectivityManager.sendForwardToIOS()
+        print("🎮 WatchCommunicationService: 5초 앞으로 전송")
+    }
+    
+    func sendBackward() {
+        connectivityManager.sendBackwardToIOS()
+        print("🎮 WatchCommunicationService: 5초 뒤로 전송")
+    }
+    
+    func sendIncreasePlayback() {
+        connectivityManager.sendIncreasePlaybackToIOS()
+        print("🎮 WatchCommunicationService: 재생 속도 증가 전송")
+    }
+    
+    func sendDecreasePlayback() {
+        connectivityManager.sendDecreasePlaybackToIOS()
+        print("🎮 WatchCommunicationService: 재생 속도 감소 전송")
+    }
+    
+    func sendOriginalPlayback() {
+        connectivityManager.sendOriginalPlaybackToIOS()
+        print("🎮 WatchCommunicationService: 원래 재생 속도 전송")
+    }
+    
+    // MARK: - Music Selection
+    
+    func sendMusicSelection(_ musicID: String) {
+        connectivityManager.sendUUIDPlayToIOS(musicID)
+        print("🎵 WatchCommunicationService: 음악 선택 전송 - ID: \(musicID)")
+    }
+    
+    // MARK: - Marker Control
+    
+    func sendMarkerPlay(at index: Int) {
+        connectivityManager.sendMarkerPlayToIOS(index)
+        print("📍 WatchCommunicationService: 마커 재생 전송 - 인덱스: \(index)")
+    }
+    
+    func sendMarkerSave(at index: Int) {
+        connectivityManager.sendMarkerSaveToIOS(index)
+        print("📍 WatchCommunicationService: 마커 저장 전송 - 인덱스: \(index)")
+    }
+    
+    func sendMarkerDelete(at index: Int) {
+        connectivityManager.sendMarkerDeleteToIOS(index)
+        print("📍 WatchCommunicationService: 마커 삭제 전송 - 인덱스: \(index)")
+    }
+    
+    func sendMarkerEditSuccess(index: Int, time: Int) {
+        connectivityManager.sendMarkerEditSuccessToIOS(forEdit: [index, time])
+        print("📍 WatchCommunicationService: 마커 편집 완료 전송 - 인덱스: \(index), 시간: \(time)")
+    }
+    
+    // MARK: - Volume Control
+    
+    func sendVolumeChange(_ volume: Float) {
+        connectivityManager.sendVolumeChangeToIOS(volume)
+        print("🔊 WatchCommunicationService: 볼륨 변경 전송 - \(volume)")
+    }
+    
+    // MARK: - Sync Requests
+    
+    func requestMusicList() {
+        connectivityManager.sendRequireMusicListToIOS()
+        print("🔄 WatchCommunicationService: 음악 목록 요청 전송")
+    }
+    
+    func requestCurrentState() {
+        connectivityManager.sendRequireCurrentStateToIOS()
+        print("🔄 WatchCommunicationService: 현재 상태 동기화 요청 전송")
+    }
+}

--- a/DancingMarker/WatchDancingMarker Watch App/Services/WatchDataService.swift
+++ b/DancingMarker/WatchDancingMarker Watch App/Services/WatchDataService.swift
@@ -1,0 +1,69 @@
+//
+//  WatchDataService.swift
+//  WatchDancingMarker Watch App
+//
+//  Created by Woowon Kang on 8/7/25.
+//
+
+import Foundation
+
+/// 워치 데이터 관리를 담당하는 서비스
+final class WatchDataService: WatchDataManageable {
+    
+    // MARK: - Properties
+    
+    private let formatter: DateComponentsFormatter
+    
+    // MARK: - Initialization
+    
+    init() {
+        // DateComponentsFormatter 설정
+        self.formatter = DateComponentsFormatter()
+        formatter.allowedUnits = [.minute, .second]
+        formatter.unitsStyle = .positional
+        formatter.zeroFormattingBehavior = [.pad]
+    }
+    
+    // MARK: - UserDefaults Management
+    
+    func saveMusicList(_ list: [[String]]) {
+        UserDefaults.standard.saveMusicList(list)
+        print("✅ WatchDataService: 음악 목록 저장 완료 - \(list.count)개")
+    }
+    
+    func getMusicList() -> [[String]] {
+        let musicList = UserDefaults.standard.getMusicList()
+        print("ℹ️ WatchDataService: 음악 목록 로드 완료 - \(musicList.count)개")
+        return musicList
+    }
+    
+    func clearMusicList() {
+        UserDefaults.standard.clearMusicList()
+        print("🗑️ WatchDataService: 음악 목록 삭제 완료")
+    }
+    
+    // MARK: - Data Processing
+    
+    func formattedTime(_ time: TimeInterval) -> String {
+        return formatter.string(from: time) ?? "0:00"
+    }
+    
+    func processMarkers(_ markers: [TimeInterval]) -> [String] {
+        return markers.map { marker in
+            if marker != -1 {
+                return formattedTime(marker)
+            } else {
+                return "99:59"
+            }
+        }
+    }
+    
+    func processPlayingTimes(_ playingTimes: [TimeInterval]) -> (currentTime: TimeInterval, duration: TimeInterval, progress: Double, formattedProgress: String) {
+        let currentTime = playingTimes[0]
+        let duration = playingTimes[1]
+        let progress = duration > 0 ? currentTime / duration : 0
+        let formattedProgress = formattedTime(currentTime)
+        
+        return (currentTime, duration, progress, formattedProgress)
+    }
+}

--- a/DancingMarker/WatchDancingMarker Watch App/Services/WatchSyncService.swift
+++ b/DancingMarker/WatchDancingMarker Watch App/Services/WatchSyncService.swift
@@ -1,0 +1,132 @@
+//
+//  WatchSyncService.swift
+//  WatchDancingMarker Watch App
+//
+//  Created by Woowon Kang on 8/7/25.
+//
+
+import Foundation
+
+/// 워치 동기화 로직을 담당하는 서비스
+final class WatchSyncService: WatchSyncable {
+    
+    // MARK: - Properties
+    
+    private let connectivityManager: WatchConnectivityManager
+    
+    // MARK: - Initialization
+    
+    init(connectivityManager: WatchConnectivityManager) {
+        self.connectivityManager = connectivityManager
+    }
+    
+    // MARK: - Connection Status
+    
+    var isReachable: Bool {
+        connectivityManager.isReachable
+    }
+    
+    // MARK: - ApplicationContext
+    
+    func getMusicListFromApplicationContext() -> [[String]]? {
+        return connectivityManager.getMusicListFromApplicationContext()
+    }
+    
+    func isApplicationContextValid() -> Bool {
+        return connectivityManager.isApplicationContextValid()
+    }
+    
+    func getLastUpdateTimeFromApplicationContext() -> TimeInterval? {
+        return connectivityManager.getLastUpdateTimeFromApplicationContext()
+    }
+    
+    // MARK: - Sync Operations
+    
+    func syncMusicList() async {
+        print("🎯 WatchSyncService: 통합 동기화 시작")
+        
+        // 1단계: ApplicationContext 먼저 확인
+        if let musicList = getMusicListFromApplicationContext() {
+            print("✅ ApplicationContext에서 음악 목록 발견: \(musicList.count)개")
+            // ApplicationContext 데이터가 있다는 것을 알림
+            NotificationCenter.default.post(name: .applicationContextLoaded, object: musicList)
+        }
+        
+        // 2단계: 연결 대기 후 실시간 요청
+        await waitForConnectionAndRequestSync()
+    }
+    
+    func waitForConnectionAndRequestSync() async {
+        print("   - 연결 대기 시작...")
+        
+        // 연결 대기 (최대 3초)
+        for attempt in 1...30 {
+            if connectivityManager.isReachable {
+                print("✅ 워치 연결됨! (시도 \(attempt)번째)")
+                break
+            }
+            
+            if attempt == 30 {
+                print("⚠️ 워치 연결 시간 초과 - ApplicationContext 데이터 사용")
+                return
+            }
+            
+            // 0.1초 대기 (100ms)
+            try? await Task.sleep(for: .milliseconds(100))
+        }
+        
+        // 실시간 동기화 요청
+        print("   - iOS 앱에 실시간 동기화 요청")
+        connectivityManager.sendRequireMusicListToIOS()
+    }
+    
+    func syncOnAppBecomesActive() async {
+        print("🔄 앱 활성화 감지 - 동기화 시작")
+        
+        // ApplicationContext 먼저 확인
+        if let musicList = getMusicListFromApplicationContext() {
+            NotificationCenter.default.post(name: .applicationContextLoaded, object: musicList)
+        }
+        
+        // 연결되어 있다면 실시간 요청도 보내기
+        if connectivityManager.isReachable {
+            connectivityManager.sendRequireMusicListToIOS()
+            
+            // 0.5초 후 재시도 (안정성)
+            try? await Task.sleep(for: .milliseconds(500))
+            connectivityManager.sendRequireMusicListToIOS()
+        }
+    }
+    
+    func forceFullSync() async {
+        print("🔄 강제 전체 동기화 시작")
+        
+        // 1단계: ApplicationContext 로드
+        if let musicList = getMusicListFromApplicationContext() {
+            NotificationCenter.default.post(name: .applicationContextLoaded, object: musicList)
+        }
+        
+        // 2단계: 실시간 요청 (여러 번)
+        for attempt in 1...3 {
+            if connectivityManager.isReachable {
+                connectivityManager.sendRequireMusicListToIOS()
+                print("   - 동기화 시도 \(attempt)/3")
+                
+                if attempt < 3 {
+                    try? await Task.sleep(for: .milliseconds(500))
+                }
+            } else {
+                print("   - 시도 \(attempt): 연결 안됨")
+                try? await Task.sleep(for: .milliseconds(200))
+            }
+        }
+        
+        print("✅ 강제 전체 동기화 완료")
+    }
+}
+
+// MARK: - Notification.Name Extension
+
+extension Notification.Name {
+    static let applicationContextLoaded = Notification.Name("ApplicationContextLoaded")
+}

--- a/DancingMarker/WatchDancingMarker Watch App/Services/WatchTimerService.swift
+++ b/DancingMarker/WatchDancingMarker Watch App/Services/WatchTimerService.swift
@@ -20,8 +20,9 @@ final class WatchTimerService: WatchTimerable {
     
     // MARK: - Initialization
     
-    init(syncService: any WatchSyncable) {
+    init(syncService: any WatchSyncable, delegate: WatchTimerDelegate? = nil) {
         self.syncService = syncService
+        self.delegate = delegate
     }
     
     // MARK: - Timer Control

--- a/DancingMarker/WatchDancingMarker Watch App/Services/WatchTimerService.swift
+++ b/DancingMarker/WatchDancingMarker Watch App/Services/WatchTimerService.swift
@@ -1,0 +1,104 @@
+//
+//  WatchTimerService.swift
+//  WatchDancingMarker Watch App
+//
+//  Created by Woowon Kang on 8/7/25.
+//
+
+import Foundation
+
+/// 워치 타이머 관리를 담당하는 서비스
+final class WatchTimerService: WatchTimerable {
+    
+    // MARK: - Properties
+    
+    private var timer: Timer?
+    private var isMarkerSeeking: Bool = false
+    private let syncService: any WatchSyncable
+    
+    weak var delegate: WatchTimerDelegate?
+    
+    // MARK: - Initialization
+    
+    init(syncService: any WatchSyncable) {
+        self.syncService = syncService
+    }
+    
+    // MARK: - Timer Control
+    
+    func startTimer() {
+        // 기존 타이머 정리
+        timer?.invalidate()
+        
+        // 새 타이머 시작
+        timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
+            self?.handleTimerUpdate()
+        }
+        
+        print("⏰ WatchTimerService: 타이머 시작됨")
+    }
+    
+    func stopTimer() {
+        timer?.invalidate()
+        timer = nil
+        print("⏰ WatchTimerService: 타이머 중지됨")
+    }
+    
+    var isTimerRunning: Bool {
+        return timer != nil
+    }
+    
+    // MARK: - Private Methods
+    
+    private func handleTimerUpdate() {
+        // 연결이 끊어졌으면 타이머 중지
+        guard syncService.isReachable else {
+            print("⚠️ 연결 끊어짐 - 타이머 중지")
+            stopTimer()
+            return
+        }
+        
+        // 델리게이트에 업데이트 알림
+        delegate?.timerDidUpdateTime()
+    }
+    
+    // MARK: - Timer State Management
+    
+    func restartTimerIfNeeded(isPlaying: Bool) {
+        if isPlaying && !isTimerRunning {
+            print("🔄 재생 중인데 타이머가 없음 - 타이머 재시작")
+            startTimer()
+        }
+    }
+    
+    func syncTimerWithPlayingState(isPlaying: Bool) {
+        if isPlaying && !isTimerRunning {
+            startTimer()
+        } else if !isPlaying && isTimerRunning {
+            stopTimer()
+        }
+    }
+    
+    // MARK: - Seeking Protection
+    
+    func withSeekingProtection<T>(_ operation: () async throws -> T) async rethrows -> T? {
+        // 이미 처리 중이면 무시
+        guard !isMarkerSeeking else {
+            print("⚠️ 마커 이동 중 - 추가 요청 무시")
+            return nil
+        }
+        
+        // 플래그 설정
+        isMarkerSeeking = true
+        
+        // 0.8초 후 플래그 해제
+        Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(800))
+            self.isMarkerSeeking = false
+            print("✅ 마커 연타 방지 플래그 해제")
+        }
+        
+        // 실제 작업 실행
+        return try await operation()
+    }
+}

--- a/DancingMarker/WatchDancingMarker Watch App/View/WatchMain/WatchMusicListView.swift
+++ b/DancingMarker/WatchDancingMarker Watch App/View/WatchMain/WatchMusicListView.swift
@@ -83,7 +83,8 @@ struct WatchMusicListView: View {
     
     private func requestMusicListSync() {
         DispatchQueue.main.async {
-            viewModel.connectivityManager.sendRequireMusicListToIOS()
+            // ✅ 새로운 방식 - ViewModel의 깔끔한 인터페이스 사용
+            viewModel.requestMusicList()
             print("음악 목록 요청 - 현재 목록: \(viewModel.musicList)")
         }
     }
@@ -95,19 +96,20 @@ extension WatchMusicListView {
     func performInitialSync() async {
         print("🎯 앱 시작 - 초기 음악 목록 동기화")
         await syncMusicList()
-        hasInitialized = true  // ✅ 같은 파일이므로 접근 가능
+        hasInitialized = true
     }
     
     func syncMusicList() async {
-        guard viewModel.connectivityManager.isReachable else {
+        // ✅ 새로운 방식 - ViewModel의 깔끔한 인터페이스 사용
+        guard viewModel.isConnected else {
             print("⚠️ 워치 연결 안됨 - 동기화 건너뜀")
             return
         }
         
-        viewModel.connectivityManager.sendRequireMusicListToIOS()
+        viewModel.requestMusicList()
         
         try? await Task.sleep(nanoseconds: 500_000_000)
-        viewModel.connectivityManager.sendRequireMusicListToIOS()
+        viewModel.requestMusicList()
         
         print("✅ 음악 목록 동기화 요청 완료")
     }

--- a/DancingMarker/WatchDancingMarker Watch App/View/WatchMain/WatchMusicListView.swift
+++ b/DancingMarker/WatchDancingMarker Watch App/View/WatchMain/WatchMusicListView.swift
@@ -27,7 +27,10 @@ struct WatchMusicListView: View {
                     if !viewModel.musicList.isEmpty && viewModel.hasSelectedMusic {
                         WatchPlayingIndicator(
                             isPlaying: viewModel.isPlaying,
-                            onTap: { navigationManager.push(to: .playing) }
+                            onTap: { 
+                                viewModel.requestImmediateSync()
+                                navigationManager.push(to: .playing) 
+                            }
                         )
                     }
                 }

--- a/DancingMarker/WatchDancingMarker Watch App/View/WatchMain/WatchMusicListView.swift
+++ b/DancingMarker/WatchDancingMarker Watch App/View/WatchMain/WatchMusicListView.swift
@@ -42,81 +42,24 @@ struct WatchMusicListView: View {
         }
         .onChange(of: scenePhase) { _, newPhase in
             if newPhase == .active {
-                handleSceneActivation()
+                viewModel.handleAppActivation()
             }
         }
         .onChange(of: afterOnAppear) { _, afterAppear in
             if afterAppear {
-                handleOnAppear()
+                viewModel.handleViewAppear()
+                afterOnAppear = false
             }
         }
     }
     
-    // MARK: - Event Handlers
+    // MARK: - Event Handlers 
     
     private func handleMusicTap(_ musicID: String) {
         DispatchQueue.main.async {
             viewModel.sendUUID(id: musicID)
             navigationManager.push(to: .playing)
         }
-    }
-    
-    private func handleSceneActivation() {
-        print("onActive")
-        requestMusicListSync()
-        
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-            requestMusicListSync()
-        }
-    }
-    
-    private func handleOnAppear() {
-        print("onAppear")
-        requestMusicListSync()
-        afterOnAppear = false
-        
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-            requestMusicListSync()
-            afterOnAppear = false
-        }
-    }
-    
-    private func requestMusicListSync() {
-        DispatchQueue.main.async {
-            // ✅ 새로운 방식 - ViewModel의 깔끔한 인터페이스 사용
-            viewModel.requestMusicList()
-            print("음악 목록 요청 - 현재 목록: \(viewModel.musicList)")
-        }
-    }
-}
-
-// MARK: - Sync Methods Extension
-extension WatchMusicListView {
-    
-    func performInitialSync() async {
-        print("🎯 앱 시작 - 초기 음악 목록 동기화")
-        await syncMusicList()
-        hasInitialized = true
-    }
-    
-    func syncMusicList() async {
-        // ✅ 새로운 방식 - ViewModel의 깔끔한 인터페이스 사용
-        guard viewModel.isConnected else {
-            print("⚠️ 워치 연결 안됨 - 동기화 건너뜀")
-            return
-        }
-        
-        viewModel.requestMusicList()
-        
-        try? await Task.sleep(nanoseconds: 500_000_000)
-        viewModel.requestMusicList()
-        
-        print("✅ 음악 목록 동기화 요청 완료")
-    }
-    
-    func syncMusicListOnAppear() async {
-        print("🎯 syncMusicListOnAppear 시작")
-        await viewModel.syncMusicListOnAppear()
     }
 }
 

--- a/DancingMarker/WatchDancingMarker Watch App/View/WatchMarkerEdit/WatchMarkerEditView.swift
+++ b/DancingMarker/WatchDancingMarker Watch App/View/WatchMarkerEdit/WatchMarkerEditView.swift
@@ -96,7 +96,8 @@ extension WatchMarkerEditView {
     // MARK: - Action Handlers
     
     func handleSave(_ finalTime: Int) {
-        viewModel.connectivityManager.sendMarkerEditSuccessToIOS(forEdit: [index, finalTime])
+        // ✅ 새로운 방식 - ViewModel의 깔끔한 인터페이스 사용
+        viewModel.saveMarkerEdit(index: index, time: finalTime)
         dismiss()
         navigationPath.removeLast(navigationPath.count)
     }

--- a/DancingMarker/WatchDancingMarker Watch App/View/WatchPlaying/WatchPlayingMarkerView.swift
+++ b/DancingMarker/WatchDancingMarker Watch App/View/WatchPlaying/WatchPlayingMarkerView.swift
@@ -8,106 +8,28 @@ struct WatchPlayingMarkerView: View {
     var body: some View {
         HStack{
             // MARK: 마커 1
-            ZStack {
-                Rectangle()
-                    .fill(viewModel.markers[0] == "99:59" ? .gray.opacity(0.2) : .accentColor)
-                    .cornerRadius(4)
-                    .frame(height: 52)
-                
-                VStack {
-                    Image(viewModel.markers[0] != "99:59" ? "addedMarker" : "emptyMarker")
-                    if viewModel.markers[0] == "99:59" {
-                        Text("Local_MarkerAdd")
-                            .foregroundStyle(.white)
-                            .font(.system(size: 12, weight: .regular))
-                            .fixedSize()
-                            .italic()
-                    } else {
-                        Text(viewModel.markers[0])
-                            .foregroundStyle(.black)
-                            .font(.system(size: 12, weight: .regular))
-                            .fixedSize()
-                            .italic()
-                    }
-                }
-            }
-            .onTapGesture {
-                if viewModel.markers[0] == "99:59"{
-                    viewModel.connectivityManager.sendMarkerSaveToIOS(0)
-                    saveMixpanelMarker()
-                } else {
-                    viewModel.connectivityManager.sendMarkerPlayToIOS(0)
-                    playMixpanelMarker1()
-                }
-            }
+            MarkerButton(
+                markerIndex: 0,
+                viewModel: viewModel,
+                onSave: saveMixpanelMarker,
+                onPlay: playMixpanelMarker1
+            )
             
-            // MARK: 마커 2
-            ZStack {
-                Rectangle()
-                    .fill(viewModel.markers[1] == "99:59" ? .gray.opacity(0.2) : .accentColor) // 마커 추가가 되었다면 ? .yellow : Color.gray.opacity(0.2)
-                    .cornerRadius(4)
-                    .frame(height: 52)
-                
-                VStack {
-                    Image(viewModel.markers[1] != "99:59" ? "addedMarker" : "emptyMarker")
-                    if viewModel.markers[1] == "99:59" {
-                        Text("Local_MarkerAdd")
-                            .foregroundStyle(.white)
-                            .font(.system(size: 12, weight: .regular))
-                            .fixedSize()
-                            .italic()
-                    } else {
-                        Text(viewModel.markers[1])
-                            .foregroundStyle(.black)
-                            .font(.system(size: 12, weight: .regular))
-                            .fixedSize()
-                            .italic()
-                    }
-                }
-            }
-            .onTapGesture {
-                if viewModel.markers[1] == "99:59"{
-                    viewModel.connectivityManager.sendMarkerSaveToIOS(1)
-                    saveMixpanelMarker()
-                } else {
-                    viewModel.connectivityManager.sendMarkerPlayToIOS(1)
-                    playMixpanelMarker2()
-                }
-            }
+            // MARK: 마커 2  
+            MarkerButton(
+                markerIndex: 1,
+                viewModel: viewModel,
+                onSave: saveMixpanelMarker,
+                onPlay: playMixpanelMarker2
+            )
             
             // MARK: 마커 3
-            ZStack {
-                Rectangle()
-                    .fill(viewModel.markers[2] == "99:59" ? .gray.opacity(0.2) : .accentColor) // 마커 추가가 되었다면 ? .yellow : Color.gray.opacity(0.2)
-                    .cornerRadius(4)
-                    .frame(height: 52)
-                
-                VStack {
-                    Image(viewModel.markers[2] != "99:59" ? "addedMarker" : "emptyMarker")
-                    if viewModel.markers[2] == "99:59" {
-                        Text("Local_MarkerAdd")
-                            .foregroundStyle(.white)
-                            .font(.system(size: 12, weight: .regular))
-                            .fixedSize()
-                            .italic()
-                    } else {
-                        Text(viewModel.markers[2])
-                            .foregroundStyle(.black)
-                            .font(.system(size: 12, weight: .regular))
-                            .fixedSize()
-                            .italic()
-                    }
-                }
-            }
-            .onTapGesture {
-                if viewModel.markers[2] == "99:59"{
-                    viewModel.connectivityManager.sendMarkerSaveToIOS(2)
-                    saveMixpanelMarker()
-                } else {
-                    viewModel.connectivityManager.sendMarkerPlayToIOS(2)
-                    playMixpanelMarker3()
-                }
-            }
+            MarkerButton(
+                markerIndex: 2,
+                viewModel: viewModel,
+                onSave: saveMixpanelMarker,
+                onPlay: playMixpanelMarker3
+            )
         }
         .padding(.bottom)
     }
@@ -130,5 +52,50 @@ struct WatchPlayingMarkerView: View {
     private func playMixpanelMarker3() {
         Mixpanel.mainInstance().track(event: "마커 재생3")
         Mixpanel.mainInstance().people.increment(property: "playMarker3", by: 1)
+    }
+}
+
+// MARK: - MarkerButton Component
+
+struct MarkerButton: View {
+    let markerIndex: Int
+    let viewModel: WatchViewModel
+    let onSave: () -> Void
+    let onPlay: () -> Void
+    
+    var body: some View {
+        ZStack {
+            Rectangle()
+                .fill(viewModel.isMarkerEmpty(at: markerIndex) ? .gray.opacity(0.2) : .accentColor)
+                .cornerRadius(4)
+                .frame(height: 52)
+            
+            VStack {
+                Image(viewModel.isMarkerEmpty(at: markerIndex) ? "emptyMarker" : "addedMarker")
+                
+                if viewModel.isMarkerEmpty(at: markerIndex) {
+                    Text("Local_MarkerAdd")
+                        .foregroundStyle(.white)
+                        .font(.system(size: 12, weight: .regular))
+                        .fixedSize()
+                        .italic()
+                } else {
+                    Text(viewModel.markers[markerIndex])
+                        .foregroundStyle(.black)
+                        .font(.system(size: 12, weight: .regular))
+                        .fixedSize()
+                        .italic()
+                }
+            }
+        }
+        .onTapGesture {
+            if viewModel.isMarkerEmpty(at: markerIndex) {
+                viewModel.saveMarker(at: markerIndex)
+                onSave()
+            } else {
+                viewModel.playMarker(at: markerIndex)
+                onPlay()
+            }
+        }
     }
 }

--- a/DancingMarker/WatchDancingMarker Watch App/View/WatchPlaying/WatchPlayingView.swift
+++ b/DancingMarker/WatchDancingMarker Watch App/View/WatchPlaying/WatchPlayingView.swift
@@ -30,14 +30,17 @@ struct WatchPlayingView: View {
             WatchPlaybackControls(
                 isPlaying: viewModel.isPlaying,
                 progress: viewModel.progress,
-                onBackward: {                    
-                    try await performBackward()
+                onBackward: {
+                    await viewModel.performBackward()
                 },
                 onPlayToggle: {
-                    await performPlayToggle()
+                    let newlyStarted = await viewModel.performPlayToggle()
+                    if newlyStarted {
+                        trackPlayEvent()  // UI 관련 로직은 View에서 OK
+                    }
                 },
                 onForward: {
-                    try await performForward()
+                    await viewModel.performForward()
                 }
             )
             
@@ -77,37 +80,17 @@ struct WatchPlayingView: View {
                 .background(Color.black)
         }
     }
-}
-
-// MARK: - Playback Actions Extension
-extension WatchPlayingView {
     
-    private func performBackward() async throws {
-        viewModel.playBackward()
-        viewModel.requestSyncWithDebounce()
-    }
-    
-    private func performForward() async throws {
-        viewModel.playForward()
-        viewModel.requestSyncWithDebounce()
-    }
-    
-    private func performPlayToggle() async {
-        let wasPlaying = viewModel.isPlaying
-        viewModel.playToggle()
-        viewModel.requestImmediateSync()
-        
-        if !wasPlaying {
-            trackPlayEvent()
-        }
-    }
+    // MARK: - UI Helper Methods (UI 관련만)
     
     private func trackPlayEvent() {
         print("📊 워치에서 노래 재생됨")
+        // Mixpanel 등 분석 도구 호출
     }
 }
 
 // MARK: - CircleProgressView
+
 struct CircleProgressView: View {
     var progress: Double
     

--- a/DancingMarker/WatchDancingMarker Watch App/ViewModel/WatchViewModel+Communication.swift
+++ b/DancingMarker/WatchDancingMarker Watch App/ViewModel/WatchViewModel+Communication.swift
@@ -1,0 +1,170 @@
+//
+//  WatchViewModel+Communication.swift
+//  WatchDancingMarker Watch App
+//
+//  Created by Woowon Kang on 8/7/25.
+//
+
+import Foundation
+
+// MARK: - Communication Methods
+
+extension WatchViewModel {
+    
+    // MARK: - Playback Control (View 전용 Public 인터페이스)
+    
+    /// 재생/일시정지 토글 (View에서 호출)
+    func playToggle() {
+        communicationService.sendPlayToggle()
+    }
+    
+    /// 5초 앞으로 이동 (View에서 호출)
+    func playForward() {
+        communicationService.sendForward()
+    }
+    
+    /// 5초 뒤로 이동 (View에서 호출)
+    func playBackward() {
+        communicationService.sendBackward()
+    }
+    
+    /// 재생 속도 감소 (View에서 호출)
+    func decreasePlaybackRate() {
+        communicationService.sendDecreasePlayback()
+    }
+    
+    /// 재생 속도 증가 (View에서 호출)
+    func increasePlaybackRate() {
+        communicationService.sendIncreasePlayback()
+    }
+    
+    /// 원래 재생 속도로 복원 (View에서 호출)
+    func originalPlaybckRate() {
+        communicationService.sendOriginalPlayback()
+    }
+    
+    // MARK: - Music Selection (View 전용 Public 인터페이스)
+    
+    /// UUID로 음악 선택 (View에서 호출)
+    func sendUUID(id: String) {
+        communicationService.sendMusicSelection(id)
+        self.hasSelectedMusic = true
+    }
+    
+    // MARK: - Marker Actions (View 전용 Public 인터페이스)
+    
+    /// 마커 저장 또는 재생 (View에서 호출)
+    func handleMarkerTap(at index: Int) {
+        if isMarkerEmpty(at: index) {
+            saveMarker(at: index)
+        } else {
+            playMarker(at: index)
+        }
+    }
+    
+    /// 마커 저장 (View에서 호출)
+    func saveMarker(at index: Int) {
+        communicationService.sendMarkerSave(at: index)
+        print("✅ ViewModel: 마커 \(index) 저장 요청")
+    }
+    
+    /// 마커 재생 (View에서 호출)
+    func playMarker(at index: Int) {
+        communicationService.sendMarkerPlay(at: index)
+        print("✅ ViewModel: 마커 \(index) 재생 요청")
+    }
+    
+    /// 마커 삭제 (View에서 호출)
+    func deletemarker(index: Int) {
+        communicationService.sendMarkerDelete(at: index)
+    }
+    
+    /// 마커 편집 완료 (View에서 호출)
+    func saveMarkerEdit(index: Int, time: Int) {
+        communicationService.sendMarkerEditSuccess(index: index, time: time)
+        print("✅ ViewModel: 마커 \(index) 편집 완료 - 시간: \(time)")
+    }
+    
+    /// 마커가 비어있는지 확인 (View에서 호출)
+    func isMarkerEmpty(at index: Int) -> Bool {
+        return markers[index] == "99:59"
+    }
+    
+    // MARK: - Volume Control (View 전용 Public 인터페이스)
+    
+    /// 볼륨 변경 (View에서 호출)
+    func changeVolume() {
+        let volumeToSend = self.crownVolume / 60
+        communicationService.sendVolumeChange(volumeToSend)
+    }
+    
+    /// Crown 값 변경 처리 (View에서 호출)
+    func handleCrownValueChange(_ newValue: Float) {
+        // 일정 수준 이상 변화했을 때만 iOS로 메시지 전송
+        let threshold: Float = 0.05  // 변화 임계값
+        if abs(newValue - lastSentCrownValue) >= threshold {
+            let volumeToSend = self.crownVolume / 60
+            communicationService.sendVolumeChange(volumeToSend)
+            lastSentCrownValue = newValue  // 마지막 전송 값 업데이트
+        }
+    }
+    
+    // MARK: - Music List Sync Actions (View 전용 Public 인터페이스)
+    
+    /// 음악 목록 동기화 요청 (View에서 호출)
+    func requestMusicList() {
+        communicationService.requestMusicList()
+        print("✅ ViewModel: 음악 목록 요청")
+    }
+    
+    /// 연결 상태 확인 (View에서 호출)
+    var isConnected: Bool {
+        communicationService.isReachable
+    }
+    
+    /// 안전한 음악 목록 동기화 (연결 상태 확인 후 요청)
+    func requestMusicListIfConnected() {
+        guard isConnected else {
+            print("⚠️ ViewModel: 워치 연결 안됨 - 동기화 건너뜀")
+            return
+        }
+        requestMusicList()
+    }
+    
+    // MARK: - Immediate Sync Methods
+    
+    /// 앞으로/뒤로 이동 후 즉시 iOS 상태 요청
+    func requestImmediateSync() {
+        print("🔄 워치: 즉시 상태 동기화 요청")
+        DispatchQueue.main.async {
+            self.communicationService.requestCurrentState()
+        }
+    }
+    
+    /// 빠른 연타 방지를 위한 debounce 동기화
+    func requestSyncWithDebounce() {
+        print("🔄 워치: debounce 동기화 요청")
+        
+        // 기존 타이머 취소
+        debounceTimer?.invalidate()
+        
+        // 0.5초 후 동기화 (마지막 동작 후에만)
+        debounceTimer = Timer.scheduledTimer(withTimeInterval: 0.5, repeats: false) { [weak self] _ in
+            self?.requestImmediateSync()
+        }
+    }
+    
+    // MARK: - Private Properties
+    
+    /// debounce를 위한 타이머
+    private var debounceTimer: Timer? {
+        get {
+            objc_getAssociatedObject(self, &debounceTimerKey) as? Timer
+        }
+        set {
+            objc_setAssociatedObject(self, &debounceTimerKey, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+        }
+    }
+}
+
+private var debounceTimerKey: UInt8 = 0

--- a/DancingMarker/WatchDancingMarker Watch App/ViewModel/WatchViewModel+Communication.swift
+++ b/DancingMarker/WatchDancingMarker Watch App/ViewModel/WatchViewModel+Communication.swift
@@ -154,6 +154,28 @@ extension WatchViewModel {
         }
     }
     
+    // MARK: - Combined Playback Actions (View에서 호출)
+    
+    /// 뒤로 이동 + 동기화 조합 (View에서 호출)
+    func performBackward() async {
+        playBackward()
+        requestSyncWithDebounce()
+    }
+    
+    /// 앞으로 이동 + 동기화 조합 (View에서 호출)
+    func performForward() async {
+        playForward()
+        requestSyncWithDebounce()
+    }
+    
+    /// 재생 토글 + 동기화 조합 (View에서 호출)
+    func performPlayToggle() async -> Bool {
+        let wasPlaying = isPlaying
+        playToggle()
+        requestImmediateSync()
+        return !wasPlaying
+    }
+    
     // MARK: - Private Properties
     
     /// debounce를 위한 타이머

--- a/DancingMarker/WatchDancingMarker Watch App/ViewModel/WatchViewModel+Data.swift
+++ b/DancingMarker/WatchDancingMarker Watch App/ViewModel/WatchViewModel+Data.swift
@@ -79,18 +79,12 @@ extension WatchViewModel {
         }
     }
     
-    // MARK: - Data Update Handlers (iOS에서 받는 데이터 업데이트)
+    // MARK: - Data Update Handlers 
     
     private func handleUpdateMarkers(_ notification: Notification) {
         if let markers = notification.object as? [TimeInterval] {
             self.timeintervalMarkers = markers
-            for index in markers.indices {
-                if markers[index] != -1 {
-                    self.markers[index] = formattedTime(markers[index])
-                } else {
-                    self.markers[index] = "99:59"
-                }
-            }
+            self.markers = dataService.processMarkers(markers)
         }
     }
     
@@ -104,23 +98,21 @@ extension WatchViewModel {
         if let isPlaying = notification.object as? Bool {
             self.isPlaying = isPlaying
             
-            if isPlaying {
-                startTimer()
-            } else {
-                stopTimer()
-            }
+            timerService.syncTimerWithPlayingState(isPlaying: isPlaying)
         } else {
             print("❌ 워치: isPlaying 값 추출 실패")
             print("   - notification.object 타입: \(type(of: notification.object))")
         }
     }
-    
+        
     private func handleUpdatePlayingTimes(_ notification: Notification) {
         if let playingTimes = notification.object as? [TimeInterval] {
-            self.currentTime = playingTimes[0]
-            self.duration = playingTimes[1]
-            self.progress = self.currentTime / self.duration
-            self.formattedProgress = self.formattedTime(self.currentTime)
+            let processed = dataService.processPlayingTimes(playingTimes)
+            
+            self.currentTime = processed.currentTime
+            self.duration = processed.duration
+            self.progress = processed.progress
+            self.formattedProgress = processed.formattedProgress
             
             // duration > 0이면 음원이 로드된 상태
             if self.duration > 0 {
@@ -128,12 +120,11 @@ extension WatchViewModel {
             }
         }
     }
-    
+        
     private func handleUpdateMusicList(_ notification: Notification) {
         if let musics = notification.object as? [[String]] {
-            // UserDefaults를 초기화하고 새로운 musicList를 저장합니다.
-            UserDefaults.standard.clearMusicList()
-            UserDefaults.standard.saveMusicList(musics)
+            dataService.clearMusicList()
+            dataService.saveMusicList(musics)
             self.musicList = musics
             self.hasSelectedMusic = false
         }
@@ -155,10 +146,6 @@ extension WatchViewModel {
     
     /// 시간을 포맷팅합니다
     func formattedTime(_ time: TimeInterval) -> String {
-        let formatter = DateComponentsFormatter()
-        formatter.allowedUnits = [.minute, .second]
-        formatter.unitsStyle = .positional
-        formatter.zeroFormattingBehavior = [.pad]
-        return formatter.string(from: time)!
+        return dataService.formattedTime(time)
     }
-} 
+}

--- a/DancingMarker/WatchDancingMarker Watch App/ViewModel/WatchViewModel+Data.swift
+++ b/DancingMarker/WatchDancingMarker Watch App/ViewModel/WatchViewModel+Data.swift
@@ -1,0 +1,164 @@
+//
+//  WatchViewModel+Data.swift
+//  WatchDancingMarker Watch App
+//
+//  Created by Woowon Kang on 8/7/25.
+//
+
+import Foundation
+
+// MARK: - Data Management Methods
+
+extension WatchViewModel {
+    
+    // MARK: - Setup Methods
+    
+    /// NotificationCenter 옵저버 설정 (iOS 패턴 - 클로저 기반)
+    func setupNotificationObservers() {
+        // 마커 업데이트
+        NotificationCenter.default.addObserver(
+            forName: .sendMarkers,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            self?.handleUpdateMarkers(notification)
+        }
+        
+        // 재생 속도 업데이트
+        NotificationCenter.default.addObserver(
+            forName: .sendSpeed,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            self?.handleUpdateSpeed(notification)
+        }
+        
+        // 재생 상태 업데이트
+        NotificationCenter.default.addObserver(
+            forName: .sendIsPlaying,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            self?.handleUpdateIsPlaying(notification)
+        }
+        
+        // 재생 시간 업데이트
+        NotificationCenter.default.addObserver(
+            forName: .sendPlayingTimes,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            self?.handleUpdatePlayingTimes(notification)
+        }
+        
+        // 음악 목록 업데이트
+        NotificationCenter.default.addObserver(
+            forName: .sendMusicList,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            self?.handleUpdateMusicList(notification)
+        }
+        
+        // 음악 제목 업데이트
+        NotificationCenter.default.addObserver(
+            forName: .sendMusicTitle,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            self?.handleUpdateMusicTitle(notification)
+        }
+        
+        // 시스템 볼륨 업데이트
+        NotificationCenter.default.addObserver(
+            forName: .sendSystemVolume,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            self?.handleSetVolumeBySystem(notification)
+        }
+    }
+    
+    // MARK: - Data Update Handlers (iOS에서 받는 데이터 업데이트)
+    
+    private func handleUpdateMarkers(_ notification: Notification) {
+        if let markers = notification.object as? [TimeInterval] {
+            self.timeintervalMarkers = markers
+            for index in markers.indices {
+                if markers[index] != -1 {
+                    self.markers[index] = formattedTime(markers[index])
+                } else {
+                    self.markers[index] = "99:59"
+                }
+            }
+        }
+    }
+    
+    private func handleUpdateSpeed(_ notification: Notification) {
+        if let speed = notification.object as? Float {
+            self.speed = speed
+        }
+    }
+    
+    private func handleUpdateIsPlaying(_ notification: Notification) {
+        if let isPlaying = notification.object as? Bool {
+            self.isPlaying = isPlaying
+            
+            if isPlaying {
+                startTimer()
+            } else {
+                stopTimer()
+            }
+        } else {
+            print("❌ 워치: isPlaying 값 추출 실패")
+            print("   - notification.object 타입: \(type(of: notification.object))")
+        }
+    }
+    
+    private func handleUpdatePlayingTimes(_ notification: Notification) {
+        if let playingTimes = notification.object as? [TimeInterval] {
+            self.currentTime = playingTimes[0]
+            self.duration = playingTimes[1]
+            self.progress = self.currentTime / self.duration
+            self.formattedProgress = self.formattedTime(self.currentTime)
+            
+            // duration > 0이면 음원이 로드된 상태
+            if self.duration > 0 {
+                self.hasSelectedMusic = true
+            }
+        }
+    }
+    
+    private func handleUpdateMusicList(_ notification: Notification) {
+        if let musics = notification.object as? [[String]] {
+            // UserDefaults를 초기화하고 새로운 musicList를 저장합니다.
+            UserDefaults.standard.clearMusicList()
+            UserDefaults.standard.saveMusicList(musics)
+            self.musicList = musics
+            self.hasSelectedMusic = false
+        }
+    }
+    
+    private func handleUpdateMusicTitle(_ notification: Notification) {
+        if let musicTitle = notification.object as? String {
+            self.musicTitle = musicTitle
+        }
+    }
+    
+    private func handleSetVolumeBySystem(_ notification: Notification) {
+        if let systemVolume = notification.object as? Float {
+            self.crownVolume = systemVolume * 60
+        }
+    }
+    
+    // MARK: - Utility Methods
+    
+    /// 시간을 포맷팅합니다
+    func formattedTime(_ time: TimeInterval) -> String {
+        let formatter = DateComponentsFormatter()
+        formatter.allowedUnits = [.minute, .second]
+        formatter.unitsStyle = .positional
+        formatter.zeroFormattingBehavior = [.pad]
+        return formatter.string(from: time)!
+    }
+} 

--- a/DancingMarker/WatchDancingMarker Watch App/ViewModel/WatchViewModel+Sync.swift
+++ b/DancingMarker/WatchDancingMarker Watch App/ViewModel/WatchViewModel+Sync.swift
@@ -7,127 +7,47 @@
 
 import Foundation
 
-// MARK: - Sync Methods
-
 extension WatchViewModel {
     
-    // MARK: - ApplicationContext 처리 메서드들
+    // MARK: - Sync Methods (모든 로직을 Service로 위임)
     
-    /// ApplicationContext에서 음악 목록을 로드합니다
+    /// 통합 동기화 메서드 (Service 사용)
+    func syncMusicListOnAppear() async {
+        await syncService.syncMusicList()
+    }
+    
+    /// ApplicationContext에서 음악 목록을 로드합니다 (Service 사용)
     func loadMusicListFromApplicationContext() {
-        if let musicList = connectivityManager.getMusicListFromApplicationContext() {
+        if let musicList = syncService.getMusicListFromApplicationContext() {
             print("✅ WatchViewModel: ApplicationContext에서 음악 목록 로드: \(musicList.count)개")
             
-            // UserDefaults에 저장
-            UserDefaults.standard.clearMusicList()
-            UserDefaults.standard.saveMusicList(musicList)
+            dataService.clearMusicList()
+            dataService.saveMusicList(musicList)
             
             // ViewModel 업데이트
             DispatchQueue.main.async {
                 self.musicList = musicList
             }
-            
-            return
         }
-        
-        print("ℹ️ WatchViewModel: ApplicationContext에 음악 목록 없음")
     }
     
-    /// ApplicationContext가 유효한지 확인합니다
+    /// ApplicationContext가 유효한지 확인합니다 (Service 사용)
     func isApplicationContextValid() -> Bool {
-        return connectivityManager.isApplicationContextValid()
+        return syncService.isApplicationContextValid()
     }
     
-    /// ApplicationContext에서 마지막 업데이트 시간을 가져옵니다
+    /// ApplicationContext에서 마지막 업데이트 시간을 가져옵니다 (Service 사용)
     func getLastUpdateTimeFromApplicationContext() -> TimeInterval? {
-        return connectivityManager.getLastUpdateTimeFromApplicationContext()
+        return syncService.getLastUpdateTimeFromApplicationContext()
     }
     
-    /// 통합 동기화 메서드 (ApplicationContext + 실시간 요청)
-    func syncMusicListOnAppear() async {
-        print("🎯 WatchViewModel: 통합 동기화 시작")
-        
-        // 1단계: ApplicationContext 먼저 확인
-        loadMusicListFromApplicationContext()
-        
-        // 2단계: 연결 대기 후 실시간 요청
-        await waitForConnectionAndRequestSync()
-    }
-    
-    /// 연결 대기 후 실시간 동기화 요청
-    private func waitForConnectionAndRequestSync() async {
-        print("   - 연결 대기 시작...")
-        
-        // 연결 대기 (최대 3초)
-        for attempt in 1...30 {
-            if connectivityManager.isReachable {
-                print("✅ 워치 연결됨! (시도 \(attempt)번째)")
-                break
-            }
-            
-            if attempt == 30 {
-                print("⚠️ 워치 연결 시간 초과 - ApplicationContext 데이터 사용")
-                return
-            }
-            
-            // ✅ 0.1초 대기 (100ms)
-            try? await Task.sleep(for: .milliseconds(100))
-        }
-        
-        // 실시간 동기화 요청
-        print("   - iOS 앱에 실시간 동기화 요청")
-        connectivityManager.sendRequireMusicListToIOS()
-    }
-
-    /// 워치에 현재 재생 상태를 전송합니다
-    func sendPlayingStateToWatch() async {
-        print("🎯 iOS: sendPlayingStateToWatch 시작")
-        print("   - isPlaying: \(isPlaying)")
-        print("   - currentTime: \(currentTime)")
-        print("   - duration: \(duration)")
-    }
-    
-    // MARK: - Background Sync Methods
-    
-    /// 앱이 백그라운드에서 포그라운드로 올 때 동기화
+    /// 앱 활성화 시 동기화 (Service 사용)
     func syncOnAppBecomesActive() async {
-        print("🔄 앱 활성화 감지 - 동기화 시작")
-        
-        // ApplicationContext 먼저 확인
-        loadMusicListFromApplicationContext()
-        
-        // 연결되어 있다면 실시간 요청도 보내기
-        if connectivityManager.isReachable {
-            connectivityManager.sendRequireMusicListToIOS()
-            
-            // 0.5초 후 재시도 (안정성)
-            try? await Task.sleep(for: .milliseconds(500))
-            connectivityManager.sendRequireMusicListToIOS()
-        }
+        await syncService.syncOnAppBecomesActive()
     }
     
-    /// 강제 전체 동기화 (사용자가 수동으로 새로고침할 때)
+    /// 강제 전체 동기화 (Service 사용)
     func forceFullSync() async {
-        print("🔄 강제 전체 동기화 시작")
-        
-        // 1단계: ApplicationContext 로드
-        loadMusicListFromApplicationContext()
-        
-        // 2단계: 실시간 요청 (여러 번)
-        for attempt in 1...3 {
-            if connectivityManager.isReachable {
-                connectivityManager.sendRequireMusicListToIOS()
-                print("   - 동기화 시도 \(attempt)/3")
-                
-                if attempt < 3 {
-                    try? await Task.sleep(for: .milliseconds(500))
-                }
-            } else {
-                print("   - 시도 \(attempt): 연결 안됨")
-                try? await Task.sleep(for: .milliseconds(200))
-            }
-        }
-        
-        print("✅ 강제 전체 동기화 완료")
+        await syncService.forceFullSync()
     }
 }

--- a/DancingMarker/WatchDancingMarker Watch App/ViewModel/WatchViewModel+Sync.swift
+++ b/DancingMarker/WatchDancingMarker Watch App/ViewModel/WatchViewModel+Sync.swift
@@ -50,4 +50,26 @@ extension WatchViewModel {
     func forceFullSync() async {
         await syncService.forceFullSync()
     }
+    
+    // MARK: - View Lifecycle Methods (WatchMusicListView에서 사용)
+    
+    /// 앱이 활성화될 때 동기화 (WatchMusicListView.handleSceneActivation에서 호출)
+    func handleAppActivation() {
+        print("🔄 앱 활성화 - 동기화 시작")
+        requestMusicList()
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            self.requestMusicList()
+        }
+    }
+    
+    /// 화면이 나타날 때 동기화 (WatchMusicListView.handleOnAppear에서 호출)
+    func handleViewAppear() {
+        print("🔄 화면 표시 - 동기화 시작")
+        requestMusicList()
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            self.requestMusicList()
+        }
+    }
 }

--- a/DancingMarker/WatchDancingMarker Watch App/ViewModel/WatchViewModel+Sync.swift
+++ b/DancingMarker/WatchDancingMarker Watch App/ViewModel/WatchViewModel+Sync.swift
@@ -1,0 +1,133 @@
+//
+//  WatchViewModel+Sync.swift
+//  WatchDancingMarker Watch App
+//
+//  Created by Woowon Kang on 8/7/25.
+//
+
+import Foundation
+
+// MARK: - Sync Methods
+
+extension WatchViewModel {
+    
+    // MARK: - ApplicationContext 처리 메서드들
+    
+    /// ApplicationContext에서 음악 목록을 로드합니다
+    func loadMusicListFromApplicationContext() {
+        if let musicList = connectivityManager.getMusicListFromApplicationContext() {
+            print("✅ WatchViewModel: ApplicationContext에서 음악 목록 로드: \(musicList.count)개")
+            
+            // UserDefaults에 저장
+            UserDefaults.standard.clearMusicList()
+            UserDefaults.standard.saveMusicList(musicList)
+            
+            // ViewModel 업데이트
+            DispatchQueue.main.async {
+                self.musicList = musicList
+            }
+            
+            return
+        }
+        
+        print("ℹ️ WatchViewModel: ApplicationContext에 음악 목록 없음")
+    }
+    
+    /// ApplicationContext가 유효한지 확인합니다
+    func isApplicationContextValid() -> Bool {
+        return connectivityManager.isApplicationContextValid()
+    }
+    
+    /// ApplicationContext에서 마지막 업데이트 시간을 가져옵니다
+    func getLastUpdateTimeFromApplicationContext() -> TimeInterval? {
+        return connectivityManager.getLastUpdateTimeFromApplicationContext()
+    }
+    
+    /// 통합 동기화 메서드 (ApplicationContext + 실시간 요청)
+    func syncMusicListOnAppear() async {
+        print("🎯 WatchViewModel: 통합 동기화 시작")
+        
+        // 1단계: ApplicationContext 먼저 확인
+        loadMusicListFromApplicationContext()
+        
+        // 2단계: 연결 대기 후 실시간 요청
+        await waitForConnectionAndRequestSync()
+    }
+    
+    /// 연결 대기 후 실시간 동기화 요청
+    private func waitForConnectionAndRequestSync() async {
+        print("   - 연결 대기 시작...")
+        
+        // 연결 대기 (최대 3초)
+        for attempt in 1...30 {
+            if connectivityManager.isReachable {
+                print("✅ 워치 연결됨! (시도 \(attempt)번째)")
+                break
+            }
+            
+            if attempt == 30 {
+                print("⚠️ 워치 연결 시간 초과 - ApplicationContext 데이터 사용")
+                return
+            }
+            
+            // ✅ 0.1초 대기 (100ms)
+            try? await Task.sleep(for: .milliseconds(100))
+        }
+        
+        // 실시간 동기화 요청
+        print("   - iOS 앱에 실시간 동기화 요청")
+        connectivityManager.sendRequireMusicListToIOS()
+    }
+
+    /// 워치에 현재 재생 상태를 전송합니다
+    func sendPlayingStateToWatch() async {
+        print("🎯 iOS: sendPlayingStateToWatch 시작")
+        print("   - isPlaying: \(isPlaying)")
+        print("   - currentTime: \(currentTime)")
+        print("   - duration: \(duration)")
+    }
+    
+    // MARK: - Background Sync Methods
+    
+    /// 앱이 백그라운드에서 포그라운드로 올 때 동기화
+    func syncOnAppBecomesActive() async {
+        print("🔄 앱 활성화 감지 - 동기화 시작")
+        
+        // ApplicationContext 먼저 확인
+        loadMusicListFromApplicationContext()
+        
+        // 연결되어 있다면 실시간 요청도 보내기
+        if connectivityManager.isReachable {
+            connectivityManager.sendRequireMusicListToIOS()
+            
+            // 0.5초 후 재시도 (안정성)
+            try? await Task.sleep(for: .milliseconds(500))
+            connectivityManager.sendRequireMusicListToIOS()
+        }
+    }
+    
+    /// 강제 전체 동기화 (사용자가 수동으로 새로고침할 때)
+    func forceFullSync() async {
+        print("🔄 강제 전체 동기화 시작")
+        
+        // 1단계: ApplicationContext 로드
+        loadMusicListFromApplicationContext()
+        
+        // 2단계: 실시간 요청 (여러 번)
+        for attempt in 1...3 {
+            if connectivityManager.isReachable {
+                connectivityManager.sendRequireMusicListToIOS()
+                print("   - 동기화 시도 \(attempt)/3")
+                
+                if attempt < 3 {
+                    try? await Task.sleep(for: .milliseconds(500))
+                }
+            } else {
+                print("   - 시도 \(attempt): 연결 안됨")
+                try? await Task.sleep(for: .milliseconds(200))
+            }
+        }
+        
+        print("✅ 강제 전체 동기화 완료")
+    }
+}

--- a/DancingMarker/WatchDancingMarker Watch App/ViewModel/WatchViewModel+Timer.swift
+++ b/DancingMarker/WatchDancingMarker Watch App/ViewModel/WatchViewModel+Timer.swift
@@ -11,108 +11,37 @@ import Foundation
 
 extension WatchViewModel {
     
-    // MARK: - Timer Control
+    // MARK: - Timer Control (Service 사용)
     
-    /// 타이머를 시작합니다 (iOS PlayerViewModel 패턴)
+    /// 타이머를 시작합니다 (Service 위임)
     internal func startTimer() {
-        // 기존 타이머 정리
-        timer?.invalidate()
-        
-        // 새 타이머 시작
-        timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
-            self?.updateTime()
-        }
-        
-        print("⏰ 타이머 시작됨")
+        timerService.startTimer()
     }
     
-    /// 타이머를 중지합니다
+    /// 타이머를 중지합니다 (Service 위임)
     internal func stopTimer() {
-        timer?.invalidate()
-        timer = nil
-        print("⏰ 타이머 중지됨")
+        timerService.stopTimer()
     }
     
-    /// 시간을 업데이트합니다 (1초마다 호출)
-    private func updateTime() {
-        // 재생 중이 아니면 업데이트 중지
-        guard isPlaying else { 
-            print("⏰ 재생 중지 상태 - 타이머 업데이트 생략")
-            return 
-        }
-        
-        // 연결이 끊어졌으면 타이머 중지
-        guard connectivityManager.isReachable else { 
-            print("⚠️ 연결 끊어짐 - 타이머 중지")
-            stopTimer()
-            return 
-        }
-        
-        // 시간 진행
-        currentTime += 1
-        
-        // 끝에 도달했으면 초기화
-        if currentTime >= duration {
-            currentTime = 0
-            stopTimer()
-            isPlaying = false
-            print("⏰ 재생 완료 - 타이머 중지")
-        }
-        
-        // UI 업데이트
-        progress = duration > 0 ? currentTime / duration : 0
-        formattedProgress = formattedTime(currentTime)
-    }
-    
-    // MARK: - Seek Protection (마커 연타 방지)
-    
-    /// 마커 연타 방지를 위한 보호 메서드 (iOS PlayerViewModel 패턴)
-    func withMarkerSeekingProtection<T>(_ operation: () async throws -> T) async rethrows -> T? {
-        // 이미 처리 중이면 무시
-        guard !isMarkerSeeking else {
-            print("⚠️ 마커 이동 중 - 추가 요청 무시")
-            return nil
-        }
-        
-        // 플래그 설정
-        isMarkerSeeking = true
-        
-        // 0.8초 후 플래그 해제 (충분한 시간 확보)
-        Task { @MainActor in
-            try? await Task.sleep(for: .milliseconds(800))
-            self.isMarkerSeeking = false
-            print("✅ 마커 연타 방지 플래그 해제")
-        }
-        
-        // 실제 작업 실행
-        return try await operation()
-    }
-    
-    // MARK: - Timer State Management
-    
-    /// 타이머 상태 확인
+    /// 타이머 상태 확인 (Service 위임)
     var isTimerRunning: Bool {
-        return timer != nil
+        timerService.isTimerRunning
     }
     
-    /// 타이머 강제 재시작 (동기화 후 사용)
+    /// 타이머 강제 재시작 (Service 위임)
     func restartTimerIfNeeded() {
-        if isPlaying && !isTimerRunning {
-            print("🔄 재생 중인데 타이머가 없음 - 타이머 재시작")
-            startTimer()
-        }
+        timerService.restartTimerIfNeeded(isPlaying: isPlaying)
     }
     
-    /// 타이머 상태를 재생 상태와 동기화
+    /// 타이머 상태 동기화 (Service 위임)
     func syncTimerWithPlayingState() {
-        if isPlaying && !isTimerRunning {
-            startTimer()
-        } else if !isPlaying && isTimerRunning {
-            stopTimer()
-        }
+        timerService.syncTimerWithPlayingState(isPlaying: isPlaying)
     }
     
-    // MARK: - Manual Time Update (동기화용)
+    /// 마커 연타 방지 (Service 위임)
+    func withMarkerSeekingProtection<T>(_ operation: () async throws -> T) async rethrows -> T? {
+        return try await timerService.withSeekingProtection(operation)
+    }
     
     /// 수동으로 시간 업데이트 (iOS에서 정확한 시간을 받았을 때)
     func updateTimeFromSync(currentTime: TimeInterval, duration: TimeInterval) {
@@ -121,7 +50,7 @@ extension WatchViewModel {
         self.currentTime = currentTime
         self.duration = duration
         self.progress = duration > 0 ? currentTime / duration : 0
-        self.formattedProgress = formattedTime(currentTime)
+        self.formattedProgress = dataService.formattedTime(currentTime)
         
         // 타이머 상태도 동기화
         syncTimerWithPlayingState()

--- a/DancingMarker/WatchDancingMarker Watch App/ViewModel/WatchViewModel+Timer.swift
+++ b/DancingMarker/WatchDancingMarker Watch App/ViewModel/WatchViewModel+Timer.swift
@@ -1,0 +1,129 @@
+//
+//  WatchViewModel+Timer.swift
+//  WatchDancingMarker Watch App
+//
+//  Created by Woowon Kang on 8/7/25.
+//
+
+import Foundation
+
+// MARK: - Timer Management Methods
+
+extension WatchViewModel {
+    
+    // MARK: - Timer Control
+    
+    /// 타이머를 시작합니다 (iOS PlayerViewModel 패턴)
+    internal func startTimer() {
+        // 기존 타이머 정리
+        timer?.invalidate()
+        
+        // 새 타이머 시작
+        timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
+            self?.updateTime()
+        }
+        
+        print("⏰ 타이머 시작됨")
+    }
+    
+    /// 타이머를 중지합니다
+    internal func stopTimer() {
+        timer?.invalidate()
+        timer = nil
+        print("⏰ 타이머 중지됨")
+    }
+    
+    /// 시간을 업데이트합니다 (1초마다 호출)
+    private func updateTime() {
+        // 재생 중이 아니면 업데이트 중지
+        guard isPlaying else { 
+            print("⏰ 재생 중지 상태 - 타이머 업데이트 생략")
+            return 
+        }
+        
+        // 연결이 끊어졌으면 타이머 중지
+        guard connectivityManager.isReachable else { 
+            print("⚠️ 연결 끊어짐 - 타이머 중지")
+            stopTimer()
+            return 
+        }
+        
+        // 시간 진행
+        currentTime += 1
+        
+        // 끝에 도달했으면 초기화
+        if currentTime >= duration {
+            currentTime = 0
+            stopTimer()
+            isPlaying = false
+            print("⏰ 재생 완료 - 타이머 중지")
+        }
+        
+        // UI 업데이트
+        progress = duration > 0 ? currentTime / duration : 0
+        formattedProgress = formattedTime(currentTime)
+    }
+    
+    // MARK: - Seek Protection (마커 연타 방지)
+    
+    /// 마커 연타 방지를 위한 보호 메서드 (iOS PlayerViewModel 패턴)
+    func withMarkerSeekingProtection<T>(_ operation: () async throws -> T) async rethrows -> T? {
+        // 이미 처리 중이면 무시
+        guard !isMarkerSeeking else {
+            print("⚠️ 마커 이동 중 - 추가 요청 무시")
+            return nil
+        }
+        
+        // 플래그 설정
+        isMarkerSeeking = true
+        
+        // 0.8초 후 플래그 해제 (충분한 시간 확보)
+        Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(800))
+            self.isMarkerSeeking = false
+            print("✅ 마커 연타 방지 플래그 해제")
+        }
+        
+        // 실제 작업 실행
+        return try await operation()
+    }
+    
+    // MARK: - Timer State Management
+    
+    /// 타이머 상태 확인
+    var isTimerRunning: Bool {
+        return timer != nil
+    }
+    
+    /// 타이머 강제 재시작 (동기화 후 사용)
+    func restartTimerIfNeeded() {
+        if isPlaying && !isTimerRunning {
+            print("🔄 재생 중인데 타이머가 없음 - 타이머 재시작")
+            startTimer()
+        }
+    }
+    
+    /// 타이머 상태를 재생 상태와 동기화
+    func syncTimerWithPlayingState() {
+        if isPlaying && !isTimerRunning {
+            startTimer()
+        } else if !isPlaying && isTimerRunning {
+            stopTimer()
+        }
+    }
+    
+    // MARK: - Manual Time Update (동기화용)
+    
+    /// 수동으로 시간 업데이트 (iOS에서 정확한 시간을 받았을 때)
+    func updateTimeFromSync(currentTime: TimeInterval, duration: TimeInterval) {
+        print("🔄 iOS에서 정확한 시간 수신 - 업데이트")
+        
+        self.currentTime = currentTime
+        self.duration = duration
+        self.progress = duration > 0 ? currentTime / duration : 0
+        self.formattedProgress = formattedTime(currentTime)
+        
+        // 타이머 상태도 동기화
+        syncTimerWithPlayingState()
+    }
+}

--- a/DancingMarker/WatchDancingMarker Watch App/ViewModel/WatchViewModel.swift
+++ b/DancingMarker/WatchDancingMarker Watch App/ViewModel/WatchViewModel.swift
@@ -9,7 +9,10 @@ import SwiftData
 
 class WatchViewModel: ObservableObject {
     
-    var connectivityManager: WatchConnectivityManager
+    // MARK: - Services
+    
+    private let communicationService: any WatchCommunicatable
+    var connectivityManager: WatchConnectivityManager  // 기존 코드 호환성을 위해 임시 유지
     @Published var musicTitle: String  = ""
     @Published var markers: [String] = ["99:59", "99:59", "99:59"]
     @Published var timeintervalMarkers: [TimeInterval] = [0.0, 0.0, 0.0]
@@ -33,6 +36,7 @@ class WatchViewModel: ObservableObject {
     
     init(connectivityManager: WatchConnectivityManager) {
         self.connectivityManager = connectivityManager
+        self.communicationService = WatchCommunicationService(connectivityManager: connectivityManager)
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(updateMarkers(_:)),
@@ -155,28 +159,30 @@ class WatchViewModel: ObservableObject {
         }
     }
     
+    // MARK: - Communication Methods (Service 위임)
+    
     func playToggle() {
-        connectivityManager.sendPlayToggleToIOS()
+        communicationService.sendPlayToggle()
     }
     
     func playForward() {
-        connectivityManager.sendForwardToIOS()
+        communicationService.sendForward()
     }
     
     func playBackward() {
-        connectivityManager.sendBackwardToIOS()
+        communicationService.sendBackward()
     }
     
     func decreasePlaybackRate() {
-        connectivityManager.sendDecreasePlaybackToIOS()
+        communicationService.sendDecreasePlayback()
     }
     
     func increasePlaybackRate() {
-        connectivityManager.sendIncreasePlaybackToIOS()
+        communicationService.sendIncreasePlayback()
     }
     
     func originalPlaybckRate() {
-        connectivityManager.sendOriginalPlaybackToIOS()
+        communicationService.sendOriginalPlayback()
     }
     
     func requireMusicList() {
@@ -184,17 +190,17 @@ class WatchViewModel: ObservableObject {
     }
     
     func sendUUID(id: String) {
-        connectivityManager.sendUUIDPlayToIOS(id)
+        communicationService.sendMusicSelection(id)
         self.hasSelectedMusic = true
     }
     
     func deletemarker(index: Int){
-        connectivityManager.sendMarkerDeleteToIOS(index)
+        communicationService.sendMarkerDelete(at: index)
     }
     
     func changeVolume(){
         let volumeToSend = self.crownVolume / 60
-        connectivityManager.sendVolumeChangeToIOS(volumeToSend)
+        communicationService.sendVolumeChange(volumeToSend)
     }
     
     func handleCrownValueChange(_ newValue: Float) {
@@ -202,7 +208,7 @@ class WatchViewModel: ObservableObject {
         let threshold: Float = 0.05  // 변화 임계값
         if abs(newValue - lastSentCrownValue) >= threshold {
             let volumeToSend = self.crownVolume / 60
-            connectivityManager.sendVolumeChangeToIOS(volumeToSend)
+            communicationService.sendVolumeChange(volumeToSend)
             lastSentCrownValue = newValue  // 마지막 전송 값 업데이트
         }
     }
@@ -370,7 +376,7 @@ extension WatchViewModel {
     func requestImmediateSync() {
         print("🔄 워치: 즉시 상태 동기화 요청")
         DispatchQueue.main.async {
-            self.connectivityManager.sendRequireCurrentStateToIOS()
+            self.communicationService.requestCurrentState()
         }
     }
     
@@ -401,3 +407,34 @@ extension WatchViewModel {
 }
 
 private var debounceTimerKey: UInt8 = 0
+
+extension WatchViewModel {
+    
+    // MARK: - Marker Actions (View 전용 Public 인터페이스)
+    
+    /// 마커 저장 또는 재생 (View에서 호출)
+    func handleMarkerTap(at index: Int) {
+        if markers[index] == "99:59" {
+            saveMarker(at: index)
+        } else {
+            playMarker(at: index)
+        }
+    }
+    
+    /// 마커 저장 (View에서 호출)
+    func saveMarker(at index: Int) {
+        communicationService.sendMarkerSave(at: index)
+        print("✅ ViewModel: 마커 \(index) 저장 요청")
+    }
+    
+    /// 마커 재생 (View에서 호출)
+    func playMarker(at index: Int) {
+        communicationService.sendMarkerPlay(at: index)
+        print("✅ ViewModel: 마커 \(index) 재생 요청")
+    }
+    
+    /// 마커가 비어있는지 확인
+    func isMarkerEmpty(at index: Int) -> Bool {
+        return markers[index] == "99:59"
+    }
+}

--- a/DancingMarker/WatchDancingMarker Watch App/ViewModel/WatchViewModel.swift
+++ b/DancingMarker/WatchDancingMarker Watch App/ViewModel/WatchViewModel.swift
@@ -1,9 +1,10 @@
 //
-//  ViewModel.swift
+//  WatchViewModel.swift
 //  WatchDancingMarker Watch App
 //
 //  Created by 변준섭 on 7/16/24.
 //
+
 import SwiftUI
 import SwiftData
 
@@ -11,264 +12,61 @@ class WatchViewModel: ObservableObject {
     
     // MARK: - Services
     
-    private let communicationService: any WatchCommunicatable
+    internal let communicationService: any WatchCommunicatable
     var connectivityManager: WatchConnectivityManager  // 기존 코드 호환성을 위해 임시 유지
-    @Published var musicTitle: String  = ""
+    
+    // MARK: - Published Properties (UI 상태만)
+    
+    @Published var musicTitle: String = ""
     @Published var markers: [String] = ["99:59", "99:59", "99:59"]
     @Published var timeintervalMarkers: [TimeInterval] = [0.0, 0.0, 0.0]
     @Published var speed: Float = 1.0
     @Published var isPlaying = false
     
-    @Published var progress: Double = 0.0 // 예시로 초기값 설정
+    @Published var progress: Double = 0.0
     @Published var formattedProgress = "0:00"
     @Published var formattedDuration = "0:00"
-    @Published var duration: TimeInterval = 0.0 // 예시로 재생 시간 설정
-    @Published var currentTime: TimeInterval = 0.0 // 예시로 현재 시간 설정
+    @Published var duration: TimeInterval = 0.0
+    @Published var currentTime: TimeInterval = 0.0
     @Published var musicList: [[String]] = []
     
-    @Published var crownVolume: Float = 0.5  // 초기 볼륨 값 (0.0 ~ 1.0)
-    @Published var lastSentCrownValue: Float = 0.5  // 마지막으로 전송된 Crown 값
-
-    @Published private var isMarkerSeeking: Bool = false
+    @Published var crownVolume: Float = 0.5
+    @Published var lastSentCrownValue: Float = 0.5
     @Published var hasSelectedMusic: Bool = false
     
-    private var timer: Timer?
+    // MARK: - Internal Properties (Extension에서 접근 가능)
+    
+    internal var timer: Timer?
+    internal var isMarkerSeeking: Bool = false
+    
+    // MARK: - Initialization
     
     init(connectivityManager: WatchConnectivityManager) {
         self.connectivityManager = connectivityManager
         self.communicationService = WatchCommunicationService(connectivityManager: connectivityManager)
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(updateMarkers(_:)),
-            name: .sendMarkers,
-            object: nil
-        )
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(updateSpeed(_:)),
-            name: .sendSpeed,
-            object: nil
-        )
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(updateIsPlaying(_:)),
-            name: .sendIsPlaying,
-            object: nil
-        )
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(updatePlayingTimes(_:)),
-            name: .sendPlayingTimes,
-            object: nil
-        )
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(updateMusicList(_:)),
-            name: .sendMusicList,
-            object: nil
-        )
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(updateMusicTitle(_:)),
-            name: .sendMusicTitle,
-            object: nil
-        )
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(setVolumeBySystem(_:)),
-            name: .sendSystemVolume,
-            object: nil
-        )
+        
+        // UserDefaults에서 음악 목록 로드
         self.musicList = UserDefaults.standard.getMusicList()
+        
+        // 초기화 작업 (Extension에서 구현)
+        setupNotificationObservers()
     }
+    
     convenience init() {
         self.init(connectivityManager: WatchConnectivityManager())
     }
     
-    @objc func updateMarkers(_ notification: Notification) {
-        if let markers = notification.object as? [TimeInterval] {
-            self.timeintervalMarkers = markers
-            for index in markers.indices{
-                if markers[index] != -1{
-                    self.markers[index] = formattedTime(markers[index])
-                } else{
-                    self.markers[index] = "99:59"
-                }
-            }
-        }
-    }
-    
-    @objc func updateSpeed(_ notification: Notification) {
-        if let speed = notification.object as? Float {
-            self.speed = speed
-        }
-    }
-    
-    @objc func updateIsPlaying(_ notification: Notification) {
-        if let isPlaying = notification.object as? Bool {
-            DispatchQueue.main.async {
-                self.isPlaying = isPlaying
-                
-                if isPlaying {
-                    self.startTimer()
-                } else {
-                    self.stopTimer()
-                }
-            }
-        } else {
-            print("❌ 워치: isPlaying 값 추출 실패")
-            print("   - notification.object 타입: \(type(of: notification.object))")
-        }
-    }
-    
-    @objc func updatePlayingTimes(_ notification: Notification) {
-        if let playingTimes = notification.object as? [TimeInterval] {
-            DispatchQueue.main.async{
-                self.currentTime = playingTimes[0]
-                self.duration = playingTimes[1]
-                self.progress = self.currentTime / self.duration
-                self.formattedProgress = self.formattedTime(self.currentTime)
-                
-                // duration > 0이면 음원이 로드된 상태
-                if self.duration > 0 {
-                    self.hasSelectedMusic = true
-                }
-            }
-        }
-    }
-    
-    @objc func updateMusicList(_ notification: Notification) {
-        if let musics = notification.object as? [[String]] {
-            // UserDefaults를 초기화하고 새로운 musicList를 저장합니다.
-            UserDefaults.standard.clearMusicList()
-            UserDefaults.standard.saveMusicList(musics)
-            self.musicList = musics
-            self.hasSelectedMusic = false
-        }
-    }
-    
-    @objc func updateMusicTitle(_ notification: Notification) {
-        if let musicTitle = notification.object as? String {
-            self.musicTitle = musicTitle
-        }
-    }
-    
-    @objc func setVolumeBySystem(_ notification: Notification) {
-        if let systemVolume = notification.object as? Float {
-            self.crownVolume = systemVolume * 60
-        }
-    }
-    
-    // MARK: - Communication Methods (Service 위임)
-    
-    func playToggle() {
-        communicationService.sendPlayToggle()
-    }
-    
-    func playForward() {
-        communicationService.sendForward()
-    }
-    
-    func playBackward() {
-        communicationService.sendBackward()
-    }
-    
-    func decreasePlaybackRate() {
-        communicationService.sendDecreasePlayback()
-    }
-    
-    func increasePlaybackRate() {
-        communicationService.sendIncreasePlayback()
-    }
-    
-    func originalPlaybckRate() {
-        communicationService.sendOriginalPlayback()
-    }
-    
-    func requireMusicList() {
-        //        connectivityManager.
-    }
-    
-    func sendUUID(id: String) {
-        communicationService.sendMusicSelection(id)
-        self.hasSelectedMusic = true
-    }
-    
-    func deletemarker(index: Int){
-        communicationService.sendMarkerDelete(at: index)
-    }
-    
-    func changeVolume(){
-        let volumeToSend = self.crownVolume / 60
-        communicationService.sendVolumeChange(volumeToSend)
-    }
-    
-    func handleCrownValueChange(_ newValue: Float) {
-        // 일정 수준 이상 변화했을 때만 iOS로 메시지 전송
-        let threshold: Float = 0.05  // 변화 임계값
-        if abs(newValue - lastSentCrownValue) >= threshold {
-            let volumeToSend = self.crownVolume / 60
-            communicationService.sendVolumeChange(volumeToSend)
-            lastSentCrownValue = newValue  // 마지막 전송 값 업데이트
-        }
-    }
-    
-    func formattedTime(_ time: TimeInterval) -> String {
-        let formatter = DateComponentsFormatter()
-        formatter.allowedUnits = [.minute, .second]
-        formatter.unitsStyle = .positional
-        formatter.zeroFormattingBehavior = [.pad]
-        return formatter.string(from: time)!
-    }
-    
-    private func startTimer() {
-        timer?.invalidate()
-        timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { _ in
-            self.updateTime()
-        }
-    }
-    
-    private func stopTimer() {
+    deinit {
+        // Timer 정리
         timer?.invalidate()
         timer = nil
-    }
-    
-    private func updateTime() {
-        guard isPlaying else { return }
         
-        guard connectivityManager.isReachable else { 
-            stopTimer()
-            return 
-        }
-        
-        currentTime += 1
-        if currentTime >= duration {
-            currentTime = 0
-            stopTimer()
-            isPlaying = false
-        }
-        progress = currentTime / duration
-        formattedProgress = formattedTime(currentTime)
-    }
-    
-    func withMarkerSeekingProtection<T>(_ operation: () async throws -> T) async rethrows -> T? {
-        guard !isMarkerSeeking else {
-            print("⚠️ 마커 이동 중 - 추가 요청 무시")
-            return nil
-        }
-        
-        isMarkerSeeking = true
-        
-        // 0.8초 후 플래그 해제 (충분한 시간 확보)
-        Task { @MainActor in
-            try? await Task.sleep(for: .milliseconds(800))
-            self.isMarkerSeeking = false
-            print("✅ 마커 연타 방지 플래그 해제")
-        }
-        
-        return try await operation()
+        // NotificationCenter 정리
+        NotificationCenter.default.removeObserver(self)
     }
 }
+
+// MARK: - UserDefaults Extension
 
 extension UserDefaults {
     private enum Keys {
@@ -285,189 +83,5 @@ extension UserDefaults {
     
     func clearMusicList() {
         removeObject(forKey: Keys.musicList)
-    }
-}
-
-// MARK: - ApplicationContext 처리 메서드들
-
-extension WatchViewModel {
-    
-    /// ApplicationContext에서 음악 목록을 로드합니다
-    func loadMusicListFromApplicationContext() {
-        if let musicList = connectivityManager.getMusicListFromApplicationContext() {
-            print("✅ WatchViewModel: ApplicationContext에서 음악 목록 로드: \(musicList.count)개")
-            
-            // UserDefaults에 저장
-            UserDefaults.standard.clearMusicList()
-            UserDefaults.standard.saveMusicList(musicList)
-            
-            // ViewModel 업데이트
-            DispatchQueue.main.async {
-                self.musicList = musicList
-            }
-            
-            return
-        }
-        
-        print("ℹ️ WatchViewModel: ApplicationContext에 음악 목록 없음")
-    }
-    
-    /// ApplicationContext가 유효한지 확인합니다
-    func isApplicationContextValid() -> Bool {
-        return connectivityManager.isApplicationContextValid()
-    }
-    
-    /// ApplicationContext에서 마지막 업데이트 시간을 가져옵니다
-    func getLastUpdateTimeFromApplicationContext() -> TimeInterval? {
-        return connectivityManager.getLastUpdateTimeFromApplicationContext()
-    }
-    
-    /// 통합 동기화 메서드 (ApplicationContext + 실시간 요청)
-    func syncMusicListOnAppear() async {
-        print(" WatchViewModel: 통합 동기화 시작")
-        
-        // 1단계: ApplicationContext 먼저 확인
-        loadMusicListFromApplicationContext()
-        
-        // 2단계: 연결 대기 후 실시간 요청
-        await waitForConnectionAndRequestSync()
-    }
-    
-    /// 연결 대기 후 실시간 동기화 요청
-    private func waitForConnectionAndRequestSync() async {
-        print("   - 연결 대기 시작...")
-        
-        // 연결 대기 (최대 3초)
-        for attempt in 1...30 {
-            if connectivityManager.isReachable {
-                print("✅ 워치 연결됨! (시도 \(attempt)번째)")
-                break
-            }
-            
-            if attempt == 30 {
-                print("⚠️ 워치 연결 시간 초과 - ApplicationContext 데이터 사용")
-                return
-            }
-            
-            // ✅ 0.1초 대기 (100ms)
-            try? await Task.sleep(for: .milliseconds(100))
-        }
-        
-        // 실시간 동기화 요청
-        print("   - iOS 앱에 실시간 동기화 요청")
-        connectivityManager.sendRequireMusicListToIOS()
-    }
-
-    /// 워치에 현재 재생 상태를 전송합니다
-    func sendPlayingStateToWatch() async {
-        print("🎯 iOS: sendPlayingStateToWatch 시작")
-        print("   - isPlaying: \(isPlaying)")
-        print("   - currentTime: \(currentTime)")
-        print("   - duration: \(duration)")
-        
-    }
-}
-
-extension WatchViewModel {
-    
-    // MARK: - Immediate Sync Methods
-    
-    /// 앞으로/뒤로 이동 후 즉시 iOS 상태 요청
-    func requestImmediateSync() {
-        print("🔄 워치: 즉시 상태 동기화 요청")
-        DispatchQueue.main.async {
-            self.communicationService.requestCurrentState()
-        }
-    }
-    
-    /// 빠른 연타 방지를 위한 debounce 동기화
-    func requestSyncWithDebounce() {
-        print("🔄 워치: debounce 동기화 요청")
-        
-        // 기존 타이머 취소
-        debounceTimer?.invalidate()
-        
-        // 0.5초 후 동기화 (마지막 동작 후에만)
-        debounceTimer = Timer.scheduledTimer(withTimeInterval: 0.5, repeats: false) { [weak self] _ in
-            self?.requestImmediateSync()
-        }
-    }
-    
-    // MARK: - Private Properties
-    
-    /// debounce를 위한 타이머
-    private var debounceTimer: Timer? {
-        get {
-            objc_getAssociatedObject(self, &debounceTimerKey) as? Timer
-        }
-        set {
-            objc_setAssociatedObject(self, &debounceTimerKey, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
-        }
-    }
-}
-
-private var debounceTimerKey: UInt8 = 0
-
-extension WatchViewModel {
-    
-    // MARK: - Marker Actions (View 전용 Public 인터페이스)
-    
-    /// 마커 저장 또는 재생 (View에서 호출)
-    func handleMarkerTap(at index: Int) {
-        if markers[index] == "99:59" {
-            saveMarker(at: index)
-        } else {
-            playMarker(at: index)
-        }
-    }
-    
-    /// 마커 저장 (View에서 호출)
-    func saveMarker(at index: Int) {
-        communicationService.sendMarkerSave(at: index)
-        print("✅ ViewModel: 마커 \(index) 저장 요청")
-    }
-    
-    /// 마커 재생 (View에서 호출)
-    func playMarker(at index: Int) {
-        communicationService.sendMarkerPlay(at: index)
-        print("✅ ViewModel: 마커 \(index) 재생 요청")
-    }
-    
-    /// 마커가 비어있는지 확인
-    func isMarkerEmpty(at index: Int) -> Bool {
-        return markers[index] == "99:59"
-    }
-}
-
-extension WatchViewModel {
-    
-    // MARK: - Marker Edit Actions (View 전용 Public 인터페이스)
-    
-    /// 마커 편집 완료 (View에서 호출)
-    func saveMarkerEdit(index: Int, time: Int) {
-        communicationService.sendMarkerEditSuccess(index: index, time: time)
-        print("✅ ViewModel: 마커 \(index) 편집 완료 - 시간: \(time)")
-    }
-    
-    // MARK: - Music List Sync Actions (View 전용 Public 인터페이스)
-    
-    /// 음악 목록 동기화 요청 (View에서 호출)
-    func requestMusicList() {
-        communicationService.requestMusicList()
-        print("✅ ViewModel: 음악 목록 요청")
-    }
-    
-    /// 연결 상태 확인 (View에서 호출)
-    var isConnected: Bool {
-        communicationService.isReachable
-    }
-    
-    /// 안전한 음악 목록 동기화 (연결 상태 확인 후 요청)
-    func requestMusicListIfConnected() {
-        guard isConnected else {
-            print("⚠️ ViewModel: 워치 연결 안됨 - 동기화 건너뜀")
-            return
-        }
-        requestMusicList()
     }
 }

--- a/DancingMarker/WatchDancingMarker Watch App/ViewModel/WatchViewModel.swift
+++ b/DancingMarker/WatchDancingMarker Watch App/ViewModel/WatchViewModel.swift
@@ -10,10 +10,12 @@ import SwiftData
 
 class WatchViewModel: ObservableObject {
     
-    // MARK: - Services
+    // MARK: - Services (모든 Service 주입)
     
     internal let communicationService: any WatchCommunicatable
-    var connectivityManager: WatchConnectivityManager  // 기존 코드 호환성을 위해 임시 유지
+    internal let syncService: any WatchSyncable
+    internal let dataService: any WatchDataManageable  
+    internal let timerService: any WatchTimerable
     
     // MARK: - Published Properties (UI 상태만)
     
@@ -42,13 +44,19 @@ class WatchViewModel: ObservableObject {
     // MARK: - Initialization
     
     init(connectivityManager: WatchConnectivityManager) {
-        self.connectivityManager = connectivityManager
         self.communicationService = WatchCommunicationService(connectivityManager: connectivityManager)
+        self.syncService = WatchSyncService(connectivityManager: connectivityManager)
+        self.dataService = WatchDataService()
+        self.timerService = WatchTimerService(syncService: self.syncService)
         
         // UserDefaults에서 음악 목록 로드
-        self.musicList = UserDefaults.standard.getMusicList()
+        self.musicList = dataService.getMusicList()
         
-        // 초기화 작업 (Extension에서 구현)
+        if let timer = timerService as? WatchTimerService {
+            timer.delegate = self
+        }
+        
+        // 초기화 작업
         setupNotificationObservers()
     }
     
@@ -83,5 +91,28 @@ extension UserDefaults {
     
     func clearMusicList() {
         removeObject(forKey: Keys.musicList)
+    }
+}
+
+// MARK: - WatchTimerDelegate
+
+extension WatchViewModel: WatchTimerDelegate {
+    func timerDidUpdateTime() {
+        // 시간 업데이트 로직 (기존 updateTime 내용)
+        currentTime += 1
+        if currentTime >= duration {
+            currentTime = 0
+            timerService.stopTimer()
+            isPlaying = false
+            print("⏰ 재생 완료")
+        }
+        
+        progress = duration > 0 ? currentTime / duration : 0
+        formattedProgress = dataService.formattedTime(currentTime)
+    }
+    
+    func timerDidComplete() {
+        isPlaying = false
+        print("⏰ 타이머 완료")
     }
 }

--- a/DancingMarker/WatchDancingMarker Watch App/ViewModel/WatchViewModel.swift
+++ b/DancingMarker/WatchDancingMarker Watch App/ViewModel/WatchViewModel.swift
@@ -438,3 +438,36 @@ extension WatchViewModel {
         return markers[index] == "99:59"
     }
 }
+
+extension WatchViewModel {
+    
+    // MARK: - Marker Edit Actions (View 전용 Public 인터페이스)
+    
+    /// 마커 편집 완료 (View에서 호출)
+    func saveMarkerEdit(index: Int, time: Int) {
+        communicationService.sendMarkerEditSuccess(index: index, time: time)
+        print("✅ ViewModel: 마커 \(index) 편집 완료 - 시간: \(time)")
+    }
+    
+    // MARK: - Music List Sync Actions (View 전용 Public 인터페이스)
+    
+    /// 음악 목록 동기화 요청 (View에서 호출)
+    func requestMusicList() {
+        communicationService.requestMusicList()
+        print("✅ ViewModel: 음악 목록 요청")
+    }
+    
+    /// 연결 상태 확인 (View에서 호출)
+    var isConnected: Bool {
+        communicationService.isReachable
+    }
+    
+    /// 안전한 음악 목록 동기화 (연결 상태 확인 후 요청)
+    func requestMusicListIfConnected() {
+        guard isConnected else {
+            print("⚠️ ViewModel: 워치 연결 안됨 - 동기화 건너뜀")
+            return
+        }
+        requestMusicList()
+    }
+}


### PR DESCRIPTION
# 주요 변경사항
## 아키텍처 개선
### WatchViewModel 분리: 기존의 거대한 ViewModel을 기능별 Extension으로 분리
- WatchViewModel+Communication.swift - 통신 관련 로직
- WatchViewModel+Sync.swift - 동기화 관련 로직
- WatchViewModel+Data.swift - 데이터 관리 로직
- WatchViewModel+Timer.swift - 타이머 관련 로직

## 서비스 기반 구조 도입
### 프로토콜 정의: 각 기능별 프로토콜 생성으로 책임 분리
- WatchSyncable - 동기화 담당
- WatchCommunicatable - 통신 담당
- WatchDataManageable - 데이터 관리 담당
- WatchTimerable - 타이머 관리 담당

## 기타 수정
- iOS에서 재생 후, watch에서 해당 음원이 아닌 재생 인디케이터 로 진입 시 음원 제목과 마커 정보가 동기화되지 않는 현상 해결
- playing만 할 뿐 동기화 해주는 코드가 없었음